### PR TITLE
Reset stock scheduler history when rescheduling

### DIFF
--- a/packages/platform-core/src/services/stockScheduler.server.ts
+++ b/packages/platform-core/src/services/stockScheduler.server.ts
@@ -35,11 +35,11 @@ export function scheduleStockChecks(
   if (existing?.timer) {
     clearInterval(existing.timer);
   }
-  const status: StockCheckStatus = existing?.status ?? {
+
+  const status: StockCheckStatus = {
     intervalMs,
     history: [],
   };
-  status.intervalMs = intervalMs;
 
   const run = async () => {
     try {


### PR DESCRIPTION
## Summary
- reset each shop's stock scheduler status when a new interval is configured so previous history entries are discarded

## Testing
- pnpm exec jest --config jest.config.cjs --coverage=false --runInBand packages/platform-core/__tests__/stockScheduler.test.ts packages-platform-core/src/services/__tests__/stockScheduler.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc15b2b5dc832fb11ba8e040fc1d41