### PR TITLE
Ensure CartContext registers sync handler before reading cache

### DIFF
--- a/packages/platform-core/src/contexts/CartContext.tsx
+++ b/packages/platform-core/src/contexts/CartContext.tsx
@@ -53,15 +53,6 @@ export function CartProvider({ children }: { children: ReactNode }) {
         throw new Error("Cart fetch failed");
       } catch (err) {
         console.error(err);
-        let cachedRaw: string | null = null;
-        try {
-          cachedRaw = localStorage.getItem(STORAGE_KEY);
-          if (cachedRaw) {
-            setState(JSON.parse(cachedRaw) as CartState);
-          }
-        } catch {
-          /* noop */
-        }
 
         sync = async () => {
           let synced = false;
@@ -115,6 +106,16 @@ export function CartProvider({ children }: { children: ReactNode }) {
         };
 
         window.addEventListener("online", sync);
+
+        let cachedRaw: string | null = null;
+        try {
+          cachedRaw = localStorage.getItem(STORAGE_KEY);
+          if (cachedRaw) {
+            setState(JSON.parse(cachedRaw) as CartState);
+          }
+        } catch {
+          /* noop */
+        }
 
         if (!cachedRaw) return;
       }


### PR DESCRIPTION
## Summary
- register the CartProvider online sync handler before touching localStorage so storage failures still set up the retry listener

## Testing
- pnpm exec jest --runInBand --config jest.config.cjs --coverage=false --runTestsByPath packages/platform-core/__tests__/CartContext.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc18743bc4832fa1e0922e971cffbc