### PR TITLE
Fix stock scheduler status history when rescheduling

### DIFF
--- a/packages/platform-core/src/services/stockScheduler.server.ts
+++ b/packages/platform-core/src/services/stockScheduler.server.ts
@@ -35,15 +35,10 @@ export function scheduleStockChecks(
   if (existing?.timer) {
     clearInterval(existing.timer);
   }
-  const status: StockCheckStatus = existing?.status ?? {
+  const status: StockCheckStatus = {
     intervalMs,
     history: [],
   };
-  if (existing?.status) {
-    status.history = [];
-    delete status.lastRun;
-  }
-  status.intervalMs = intervalMs;
 
   const run = async () => {
     try {


### PR DESCRIPTION
## Summary
- create a fresh `StockCheckStatus` object on every schedule so stale timers cannot push duplicate history entries after rescheduling
- add a regression test that covers rescheduling while a run is still in flight to ensure only the new interval contributes history

## Testing
- pnpm exec jest packages/platform-core/src/services/__tests__/stockScheduler.test.ts --runInBand --detectOpenHandles --config jest.config.cjs --coverage=false
- pnpm exec jest packages/platform-core/__tests__/stockScheduler.test.ts --runInBand --detectOpenHandles --config jest.config.cjs --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cc1b2e2854832f8004a92867da6150