### PR TITLE
Use shared Button atom in media upload flow

### DIFF
--- a/packages/ui/__tests__/Library.test.tsx
+++ b/packages/ui/__tests__/Library.test.tsx
@@ -1,14 +1,22 @@
-jest.mock("@ui/components/atoms/shadcn", () => {
+function createShadcnStub() {
   const React = require("react");
   return {
     Input: (props: any) => <input {...props} />,
+    Button: ({ children, ...rest }: any) => (
+      <button type="button" {...rest}>
+        {children}
+      </button>
+    ),
     Select: ({ children, ...rest }: any) => <select {...rest}>{children}</select>,
     SelectTrigger: ({ children }: any) => <div>{children}</div>,
     SelectValue: ({ placeholder }: any) => <option>{placeholder}</option>,
     SelectContent: ({ children }: any) => <div>{children}</div>,
     SelectItem: ({ children, ...rest }: any) => <option {...rest}>{children}</option>,
   };
-});
+}
+
+jest.mock("@/components/atoms/shadcn", createShadcnStub);
+jest.mock("../src/components/atoms/shadcn", createShadcnStub);
 const mockMediaFileList = jest.fn(
   ({ files, onDelete, isItemSelected }: any) => (
     <div>

--- a/packages/ui/__tests__/MediaManager.test.tsx
+++ b/packages/ui/__tests__/MediaManager.test.tsx
@@ -1,7 +1,8 @@
 jest.mock("@cms/actions/media.server", () => ({
   deleteMedia: jest.fn(),
 }));
-jest.mock("@ui/components/atoms/shadcn", () => {
+
+function createShadcnStub() {
   const React = require("react");
   const passthrough = (tag = "div") =>
     React.forwardRef(({ asChild: _asChild, ...props }: any, ref: any) =>
@@ -69,7 +70,10 @@ jest.mock("@ui/components/atoms/shadcn", () => {
     DialogDescription: ({ children }: any) => <div>{children}</div>,
     DialogFooter: ({ children }: any) => <div>{children}</div>,
   };
-});
+}
+
+jest.mock("@/components/atoms/shadcn", createShadcnStub);
+jest.mock("../src/components/atoms/shadcn", createShadcnStub);
 import { deleteMedia } from "@cms/actions/media.server";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useImageOrientationValidation } from "@ui/hooks/useImageOrientationValidation";
@@ -110,7 +114,7 @@ describe("MediaManager", () => {
         onMetadataUpdate={mockMetadataUpdate}
       />
     );
-    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getAllByRole("menuitem", { name: "Delete" })[0]);
     await waitFor(() =>
       expect(mockDelete).toHaveBeenCalledWith("s", "/img.jpg")
     );
@@ -152,10 +156,10 @@ describe("MediaManager", () => {
         onMetadataUpdate={mockMetadataUpdate}
       />
     );
-    expect(screen.getAllByText("Delete")).toHaveLength(2);
+    expect(screen.getAllByRole("menuitem", { name: "Delete" })).toHaveLength(2);
     fireEvent.change(screen.getByPlaceholderText("Search media..."), {
       target: { value: "dog" },
     });
-    expect(screen.getAllByText("Delete")).toHaveLength(1);
+    expect(screen.getAllByRole("menuitem", { name: "Delete" })).toHaveLength(1);
   });
 });

--- a/packages/ui/__tests__/UploadPanel.test.tsx
+++ b/packages/ui/__tests__/UploadPanel.test.tsx
@@ -1,8 +1,9 @@
 jest.mock("@ui/hooks/useMediaUpload", () => ({ useMediaUpload: jest.fn() }));
-jest.mock("@ui/components/atoms/shadcn", () => {
+jest.mock("@/components/atoms/shadcn", () => {
   const React = require("react");
   return {
     Input: React.forwardRef((props, ref) => <input ref={ref} {...props} />),
+    Button: React.forwardRef((props, ref) => <button ref={ref} {...props} />),
   };
 });
 import { useMediaUpload } from "@ui/hooks/useMediaUpload";

--- a/packages/ui/__tests__/useFileUpload.test.tsx
+++ b/packages/ui/__tests__/useFileUpload.test.tsx
@@ -2,6 +2,17 @@ import { act, fireEvent, render, renderHook } from "@testing-library/react";
 import useFileUpload from "../src/hooks/useFileUpload";
 import { useImageOrientationValidation } from "../src/hooks/useImageOrientationValidation";
 
+function createShadcnStub() {
+  const React = require("react");
+  return {
+    Button: React.forwardRef((props: any, ref: any) => (
+      <button ref={ref} {...props} />
+    )),
+  };
+}
+
+jest.mock("@/components/atoms/shadcn", createShadcnStub);
+jest.mock("../src/components/atoms/shadcn", createShadcnStub);
 jest.mock("../src/hooks/useImageOrientationValidation");
 
 const originalFetch = global.fetch;

--- a/packages/ui/src/components/cms/media/UploadPanel.tsx
+++ b/packages/ui/src/components/cms/media/UploadPanel.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import Image from "next/image";
-import { Input } from "../../atoms/shadcn";
+import { Button, Input } from "@/components/atoms/shadcn";
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useMediaUpload } from "@ui/hooks/useMediaUpload";
 import { ChangeEvent, ReactElement, useEffect, useState } from "react";
@@ -143,10 +143,10 @@ export default function UploadPanel({
                   placeholder="Tags (comma separated)"
                   className="flex-1"
                 />
-                <button
+                <Button
                   onClick={handleUpload}
                   type="button"
-                  className="rounded bg-primary px-2 text-sm text-primary-fg"
+                  className="h-auto px-2 py-1 text-sm"
                   disabled={isUploading}
                 >
                   {isUploading ? (
@@ -159,7 +159,7 @@ export default function UploadPanel({
                   ) : (
                     "Upload"
                   )}
-                </button>
+                </Button>
               </div>
             )}
           </div>

--- a/packages/ui/src/components/cms/media/__tests__/UploadPanel.test.tsx
+++ b/packages/ui/src/components/cms/media/__tests__/UploadPanel.test.tsx
@@ -4,10 +4,13 @@ import UploadPanel from "../UploadPanel";
 import { useMediaUpload } from "@ui/hooks/useMediaUpload";
 
 jest.mock("@ui/hooks/useMediaUpload", () => ({ useMediaUpload: jest.fn() }));
-jest.mock("@ui/components/atoms/shadcn", () => {
+jest.mock("@/components/atoms/shadcn", () => {
   const React = require("react");
   return {
     Input: React.forwardRef((props: any, ref: any) => <input ref={ref} {...props} />),
+    Button: React.forwardRef((props: any, ref: any) => (
+      <button ref={ref} {...props} />
+    )),
   };
 });
 

--- a/packages/ui/src/hooks/__tests__/useFileUpload.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useFileUpload.test.tsx
@@ -1,5 +1,16 @@
 import { act, fireEvent, render, renderHook } from "@testing-library/react";
 
+function createShadcnStub() {
+  const React = require("react");
+  return {
+    Button: React.forwardRef((props: any, ref: any) => (
+      <button ref={ref} {...props} />
+    )),
+  };
+}
+
+jest.mock("@/components/atoms/shadcn", createShadcnStub);
+
 jest.mock("../useImageOrientationValidation.ts", () => ({
   useImageOrientationValidation: jest.fn(),
 }));

--- a/packages/ui/src/hooks/useFileUpload.tsx
+++ b/packages/ui/src/hooks/useFileUpload.tsx
@@ -11,6 +11,7 @@ import type { ChangeEvent, DragEvent, ReactElement, RefObject } from "react";
 import { useCallback, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
+import { Button } from "@/components/atoms/shadcn";
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useImageOrientationValidation } from "./useImageOrientationValidation";
 
@@ -196,13 +197,13 @@ export function useFileUpload(
       />
 
       <p className="mb-2">Drag &amp; drop or</p>
-      <button
+      <Button
         type="button"
         onClick={openFileDialog}
-        className="bg-primary text-primary-fg rounded px-3 py-1"
+        className="h-auto px-3 py-1 text-sm"
       >
         Browse…
-      </button>
+      </Button>
 
       <div id={feedbackId} role="status" aria-live="polite">
         {pendingFile && (


### PR DESCRIPTION
## Summary
- import the shadcn Button atom in the media UploadPanel component and use it for the upload call-to-action while keeping the existing sizing
- reuse the shared Button in the useFileUpload hook’s uploader UI so both entry points share the same atom
- adjust related tests to stub the Button export and update MediaManager assertions after the new wrapper

## Testing
- pnpm exec jest --config jest.config.cjs --runTestsByPath packages/ui/src/components/cms/media/__tests__/UploadPanel.test.tsx packages/ui/__tests__/UploadPanel.test.tsx packages/ui/__tests__/MediaManager.test.tsx packages/ui/__tests__/Library.test.tsx packages/ui/__tests__/useFileUpload.test.tsx packages/ui/src/hooks/__tests__/useFileUpload.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc512e0c84832f8fedcc6b088eb331