### PR TITLE
feat(ui): use tailwind classes for uploader highlight

### DIFF
--- a/packages/ui/__tests__/useFileUpload.test.tsx
+++ b/packages/ui/__tests__/useFileUpload.test.tsx
@@ -105,19 +105,22 @@ describe("useFileUpload", () => {
     );
     const { container, rerender } = render(result.current.uploader);
 
-    fireEvent.dragEnter(container.firstChild!);
+    const dropzone = container.firstChild as HTMLElement;
+
+    fireEvent.dragEnter(dropzone);
     rerender(result.current.uploader);
-    expect(container.firstChild?.className).toContain("highlighted");
+    expect(dropzone).toHaveClass("ring-2");
+    expect(dropzone).toHaveClass("bg-primary/5");
 
     act(() => {
-      fireEvent.drop(container.firstChild!, {
+      fireEvent.drop(dropzone, {
         dataTransfer: { files: [file] },
       });
     });
     rerender(result.current.uploader);
 
     expect(result.current.pendingFile).toBe(file);
-    expect(container.firstChild?.className).not.toContain("highlighted");
+    expect(dropzone).not.toHaveClass("ring-2");
   });
 
   it("shows orientation warning when mismatched", () => {

--- a/packages/ui/src/components/cms/__tests__/media-manager.integration.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/media-manager.integration.test.tsx
@@ -299,14 +299,20 @@ describe("Media manager integration", () => {
     });
 
     fireEvent.dragEnter(dropzone);
-    expect(dropzone.className).toMatch(/highlighted/);
+    expect(dropzone).toHaveClass("ring-2");
+    expect(dropzone).toHaveClass("ring-primary/60");
+    expect(dropzone).toHaveClass("bg-primary/5");
     fireEvent.dragLeave(dropzone);
-    expect(dropzone.className).not.toMatch(/highlighted/);
+    expect(dropzone).not.toHaveClass("ring-2");
+    expect(dropzone).not.toHaveClass("ring-primary/60");
+    expect(dropzone).not.toHaveClass("bg-primary/5");
 
     fireEvent.dragEnter(dropzone);
     const file = new File(["binary"], "hero.png", { type: "image/png" });
     fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
-    expect(dropzone.className).not.toMatch(/highlighted/);
+    expect(dropzone).not.toHaveClass("ring-2");
+    expect(dropzone).not.toHaveClass("ring-primary/60");
+    expect(dropzone).not.toHaveClass("bg-primary/5");
 
     await screen.findByPlaceholderText("Alt text");
 
@@ -314,9 +320,11 @@ describe("Media manager integration", () => {
 
     const uploadedLabels = await screen.findAllByText("Uploaded hero.png");
     expect(uploadedLabels.length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByRole("button", { name: /media actions/i })
-    ).toHaveLength(3);
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("button", { name: "Media actions", hidden: true })
+      ).toHaveLength(3)
+    );
     await waitFor(() =>
       expect(screen.queryByPlaceholderText("Alt text")).not.toBeInTheDocument()
     );

--- a/packages/ui/src/components/cms/media/UploadPanel.tsx
+++ b/packages/ui/src/components/cms/media/UploadPanel.tsx
@@ -7,6 +7,7 @@ import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useMediaUpload } from "@ui/hooks/useMediaUpload";
 import { ChangeEvent, ReactElement, useEffect, useState } from "react";
 import { Spinner } from "../../atoms";
+import { cn } from "../../../utils/style";
 
 interface UploadPanelProps {
   shop: string;
@@ -76,9 +77,10 @@ export default function UploadPanel({
             openFileDialog();
           }
         }}
-        className={`flex h-32 cursor-pointer items-center justify-center rounded-md border-2 border-dashed border-muted text-sm text-muted${
-          dragActive ? " highlighted" : ""
-        }`}
+        className={cn(
+          "flex h-32 cursor-pointer items-center justify-center rounded-md border-2 border-dashed border-muted text-sm text-muted",
+          dragActive && "ring-2 ring-primary/60 bg-primary/5"
+        )}
       >
         <Input
           ref={inputRef}

--- a/packages/ui/src/components/cms/media/__tests__/UploadPanel.test.tsx
+++ b/packages/ui/src/components/cms/media/__tests__/UploadPanel.test.tsx
@@ -47,14 +47,15 @@ describe("UploadPanel", () => {
       name: /drop image or video here or press enter to browse/i,
     });
     fireEvent.dragEnter(dropzone);
-    expect(dropzone.className).toMatch(/highlighted/);
+    expect(dropzone).toHaveClass("ring-2");
+    expect(dropzone).toHaveClass("bg-primary/5");
     fireEvent.dragLeave(dropzone);
-    expect(dropzone.className).not.toMatch(/highlighted/);
+    expect(dropzone).not.toHaveClass("ring-2");
     fireEvent.dragEnter(dropzone);
     const file = new File(["x"], "x.png", { type: "image/png" });
     fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
     expect(onDrop).toHaveBeenCalled();
-    expect(dropzone.className).not.toMatch(/highlighted/);
+    expect(dropzone).not.toHaveClass("ring-2");
   });
 
   it("opens file dialog with keyboard", () => {

--- a/packages/ui/src/hooks/__tests__/useFileUpload.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useFileUpload.test.tsx
@@ -303,12 +303,13 @@ it("highlights dropzone on drag enter and removes highlight on drag leave", () =
     fireEvent.dragOver(dropzone);
     fireEvent.dragEnter(dropzone);
   });
-  expect(dropzone.className).toContain("highlighted");
+  expect(dropzone).toHaveClass("ring-2");
+  expect(dropzone).toHaveClass("bg-primary/5");
 
   act(() => {
     fireEvent.dragLeave(dropzone);
   });
-  expect(dropzone.className).not.toContain("highlighted");
+  expect(dropzone).not.toHaveClass("ring-2");
 });
 
 it("returns early when no file is pending", async () => {

--- a/packages/ui/src/hooks/useFileUpload.tsx
+++ b/packages/ui/src/hooks/useFileUpload.tsx
@@ -13,6 +13,7 @@ import { flushSync } from "react-dom";
 
 import type { ImageOrientation, MediaItem } from "@acme/types";
 import { useImageOrientationValidation } from "./useImageOrientationValidation";
+import { cn } from "../utils/style";
 
 /* ──────────────────────────────────────────────────────────────────────
  * Public API types
@@ -182,9 +183,10 @@ export function useFileUpload(
           openFileDialog();
         }
       }}
-      className={`rounded border-2 border-dashed p-4 text-center${
-        dragActive ? "highlighted" : ""
-      }`}
+      className={cn(
+        "rounded border-2 border-dashed p-4 text-center",
+        dragActive && "ring-2 ring-primary/60 bg-primary/5"
+      )}
     >
       {/* hidden file input */}
       <input


### PR DESCRIPTION
## Summary
- swap the uploader drop-zone templates to use `cn(...)` with explicit Tailwind ring/background utilities instead of the legacy `highlighted` token
- keep the shared `useFileUpload` hook in sync with the same Tailwind classes
- update uploader and media manager tests to assert the new visual-state classes and a stable selector for uploaded media rows

## Testing
- pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runInBand --runTestsByPath src/components/cms/media/__tests__/UploadPanel.test.tsx __tests__/useFileUpload.test.tsx src/hooks/__tests__/useFileUpload.test.tsx src/components/cms/__tests__/media-manager.integration.test.tsx --coverage=false
- pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/src/components/cms/media/__tests__/UploadPanel.test.tsx packages/ui/__tests__/useFileUpload.test.tsx packages/ui/src/hooks/__tests__/useFileUpload.test.tsx packages/ui/src/components/cms/__tests__/media-manager.integration.test.tsx *(fails coverage threshold as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68cc51277b4c832faf2a29b9e768e6d3