### PR TITLE
Emphasize single-purpose, small files in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,12 @@
 - If `pnpm run dev` fails with an `array.length` error, run the appropriate Codex command to retrieve detailed failure logs.
 - Apps must map workspace packages in their `tsconfig.json` to both built `dist` files and raw `src` sources so TypeScript can resolve imports even when packages haven't been built.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## Role
 When completing security work, you are a senior secure-code reviewer. Your goal is to surface high-impact security risks fast, explain exploitability, and propose minimal, safe fixes with tests.
 

--- a/packages/auth/AGENTS.md
+++ b/packages/auth/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Authentication utilities and session helpers.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/config/AGENTS.md
+++ b/packages/config/AGENTS.md
@@ -3,9 +3,14 @@
 ## Purpose
 Exposes configuration files through generated JavaScript stubs backed by TypeScript implementations.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## Regenerating Stubs
 Run `pnpm run build:stubs` whenever a `*.impl.ts` file changes to rebuild the JavaScript stubs. This command runs `scripts/generate-env-stubs.mjs`, which scans `src/env/*.impl.ts` and writes matching `.js` files that re-export the compiled implementations.
-
 ## Tooling
 - **Next.js** loads the `*.js` stubs for runtime configuration.
 - **Jest** resolves the stubs so tests run without a custom transformer.

--- a/packages/configurator/AGENTS.md
+++ b/packages/configurator/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 CLI for generating configuration files.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/date-utils/AGENTS.md
+++ b/packages/date-utils/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Date and time helper functions.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/design-tokens/AGENTS.md
+++ b/packages/design-tokens/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Shared design tokens for styling.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/email-templates/AGENTS.md
+++ b/packages/email-templates/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Reusable email template components.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/email/AGENTS.md
+++ b/packages/email/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Email sending utilities.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/eslint-plugin-ds/AGENTS.md
+++ b/packages/eslint-plugin-ds/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 ESLint rules for the design system.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/i18n/AGENTS.md
+++ b/packages/i18n/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Internationalization helpers and message formatting.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/lib/AGENTS.md
+++ b/packages/lib/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Common library helpers.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/platform-core/AGENTS.md
+++ b/packages/platform-core/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Core services for the platform.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/platform-machine/AGENTS.md
+++ b/packages/platform-machine/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Machine-oriented platform utilities.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/sanity/AGENTS.md
+++ b/packages/sanity/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Sanity CMS integration helpers.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/shared-utils/AGENTS.md
+++ b/packages/shared-utils/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Utilities shared across packages.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/stripe/AGENTS.md
+++ b/packages/stripe/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Stripe API integration utilities.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/tailwind-config/AGENTS.md
+++ b/packages/tailwind-config/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Tailwind CSS base configuration.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/telemetry/AGENTS.md
+++ b/packages/telemetry/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Telemetry and analytics helpers.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/template-app/AGENTS.md
+++ b/packages/template-app/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Starter application template.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/theme/AGENTS.md
+++ b/packages/theme/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Theming helpers and default theme.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/types/AGENTS.md
+++ b/packages/types/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Shared TypeScript type definitions.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 UI component library.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo

--- a/packages/zod-utils/AGENTS.md
+++ b/packages/zod-utils/AGENTS.md
@@ -3,13 +3,18 @@
 ## Purpose
 Helpers for working with Zod schemas.
 
+## File Organization Guidance
+
+- Keep each file focused on a single clear responsibility instead of mixing unrelated concerns.
+- Aim to keep every file under 350 lines of code. When exceeding this limit is absolutely necessary (for example, generated output or framework-required structure), document the justification and plan for follow-up refactors.
+- Prefer extracting helpers, components, and modules rather than growing a file past the limit.
+
 ## TypeScript Build Contract
 - `compilerOptions.composite` is `true`
 - `declaration` and `declarationMap` are `true`
 - `rootDir` is `"src"` and `outDir` is `"dist"`
 - `package.json` includes `"types": "dist/index.d.ts"`
 - Add a project reference in `tsconfig.json` when importing this package.
-
 ## Clean & Rebuild
 ```sh
 rimraf dist tsconfig.tsbuildinfo


### PR DESCRIPTION
## Summary
- add repository-wide guidance reminding contributors to keep files single-purpose and under 350 LOC unless necessary
- embed the same file-organization expectations across each package-level AGENTS.md file so the advice is visible during local work

## Testing
- not run (not needed for documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cd0ba66234832fa84a60197a6adef8