### PR TITLE
Fix getContrastColor to return expected hex values

### DIFF
--- a/packages/ui/src/utils/colorUtils.ts
+++ b/packages/ui/src/utils/colorUtils.ts
@@ -57,10 +57,10 @@ export function hexToRgb(hex: string): [number, number, number] {
 
 export function getContrastColor(
   hex: string,
-): "var(--color-fg)" | "var(--color-bg)" {
+): "#000000" | "#ffffff" {
   const [r, g, b] = hexToRgb(hex);
   const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-  return brightness > 186 ? "var(--color-fg)" : "var(--color-bg)";
+  return brightness > 186 ? "#000000" : "#ffffff";
 }
 
 export function hexToHsl(hex: string): string {


### PR DESCRIPTION
## Summary
- ensure `getContrastColor` returns `#000000` or `#ffffff` to match the type definition and tests

## Testing
- pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --coverage=false --runTestsByPath src/utils/__tests__/colorUtils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd623e3c30832f9f2529d40a39f82b