### PR TITLE
Fix StoreLocatorBlock test selectors and compute Logo srcSet

### DIFF
--- a/packages/ui/src/components/cms/blocks/__tests__/StoreLocatorBlock.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/StoreLocatorBlock.test.tsx
@@ -5,7 +5,7 @@ jest.mock("../../../organisms/StoreLocatorMap", () => {
   const React = require("react");
   return {
     __esModule: true,
-    StoreLocatorMap: jest.fn(() => <div data-testid="map-view" />),
+    StoreLocatorMap: jest.fn(() => <div data-cy="map-view" />),
   };
 });
 
@@ -23,7 +23,7 @@ describe("StoreLocatorBlock", () => {
 
   afterEach(() => {
     mockStoreLocatorMap.mockReset();
-    mockStoreLocatorMap.mockImplementation(() => <div data-testid="map-view" />);
+    mockStoreLocatorMap.mockImplementation(() => <div data-cy="map-view" />);
   });
 
   it("switches between map and list modes", () => {
@@ -35,7 +35,7 @@ describe("StoreLocatorBlock", () => {
     expect(getByTestId("map-view")).toBeInTheDocument();
 
     mockStoreLocatorMap.mockImplementationOnce(() => (
-      <ul data-testid="list-view">
+      <ul data-cy="list-view">
         {locations.map((loc) => (
           <li key={loc.label}>{loc.label}</li>
         ))}


### PR DESCRIPTION
## Summary
- update the StoreLocatorBlock tests to use the global data-cy test id attribute
- compute a responsive srcSet for the Logo component based on the provided sources

## Testing
- pnpm exec jest packages/ui/src/components/cms/blocks/__tests__/StoreLocatorBlock.test.tsx packages/ui/__tests__/Logo.test.tsx --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cd6256f198832f911d5e35a04b7448