### PR TITLE
Fix MediaManager delete accessibility labels

### DIFF
--- a/apps/cms/src/components/cms/media/__tests__/MediaManager.test.tsx
+++ b/apps/cms/src/components/cms/media/__tests__/MediaManager.test.tsx
@@ -163,6 +163,10 @@ describe("MediaManager", () => {
   const originalFetch = global.fetch;
   const originalConfirm = window.confirm;
 
+  beforeEach(() => {
+    window.confirm = undefined as any;
+  });
+
   afterEach(() => {
     global.fetch = originalFetch;
     window.confirm = originalConfirm;
@@ -207,7 +211,7 @@ describe("MediaManager", () => {
       expect(queryByText("Uploaded 0/1")).not.toBeInTheDocument()
     );
     await waitFor(() =>
-      expect(queryAllByRole("menuitem", { name: "Delete media" })).toHaveLength(1)
+      expect(queryAllByRole("menuitem", { name: "Delete" })).toHaveLength(1)
     );
   });
 
@@ -223,7 +227,7 @@ describe("MediaManager", () => {
     );
 
     fireEvent.click(getByRole("button", { name: "Media actions" }));
-    fireEvent.click(getByRole("menuitem", { name: "Delete media" }));
+    fireEvent.click(getByRole("menuitem", { name: "Delete" }));
 
     const confirmDeleteButton = getByRole("button", { name: "Delete" });
     fireEvent.click(confirmDeleteButton);
@@ -235,7 +239,7 @@ describe("MediaManager", () => {
       expect(queryByRole("button", { name: "Delete" })).not.toBeInTheDocument()
     );
     await waitFor(() =>
-      expect(queryAllByRole("menuitem", { name: "Delete media" })).toHaveLength(0)
+      expect(queryAllByRole("menuitem", { name: "Delete" })).toHaveLength(0)
     );
   });
 

--- a/packages/ui/src/components/cms/MediaFileActions.tsx
+++ b/packages/ui/src/components/cms/MediaFileActions.tsx
@@ -111,6 +111,7 @@ export function MediaFileActions({
               }}
               disabled={actionsDisabled}
               className="flex items-center gap-2"
+              aria-label={replaceInProgress ? "Replacing media" : "Replace"}
             >
               {renderLoadingContent("Replace", replaceInProgress, "Replacing media…")}
             </DropdownMenuItem>
@@ -122,6 +123,7 @@ export function MediaFileActions({
               }}
               disabled={actionsDisabled}
               className="flex items-center gap-2"
+              aria-label={deleteInProgress ? "Deleting media" : "Delete"}
             >
               {renderLoadingContent("Delete", deleteInProgress, "Deleting media…")}
             </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- ensure the media action menu exposes stable Replace/Delete labels by setting explicit aria-labels
- align the CMS MediaManager tests with the new Delete label and stub window.confirm so the dialog flow is exercised

## Testing
- pnpm --filter @apps/cms test -- --runTestsByPath apps/cms/src/components/cms/media/__tests__/MediaManager.test.tsx
- pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runTestsByPath __tests__/MediaManager.test.tsx --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68cd61e5ad80832fbe671b114e505aba