### PR TITLE
Add missing page component schemas

### DIFF
--- a/packages/types/src/page/atoms/Divider.ts
+++ b/packages/types/src/page/atoms/Divider.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { baseComponentSchema, type PageComponentBase } from "../base";
+
+export interface DividerComponent extends PageComponentBase {
+  type: "Divider";
+  /** Thickness of the divider */
+  height?: string;
+}
+
+export const dividerComponentSchema = baseComponentSchema.extend({
+  type: z.literal("Divider"),
+  height: z.string().optional(),
+});
+

--- a/packages/types/src/page/atoms/Spacer.ts
+++ b/packages/types/src/page/atoms/Spacer.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { baseComponentSchema, type PageComponentBase } from "../base";
+
+export interface SpacerComponent extends PageComponentBase {
+  type: "Spacer";
+  /** Amount of vertical whitespace */
+  height?: string;
+}
+
+export const spacerComponentSchema = baseComponentSchema.extend({
+  type: z.literal("Spacer"),
+  height: z.string().optional(),
+});
+

--- a/packages/types/src/page/atoms/index.ts
+++ b/packages/types/src/page/atoms/index.ts
@@ -2,3 +2,5 @@ export * from "./Image";
 export * from "./Text";
 export * from "./CustomHtml";
 export * from "./Button";
+export * from "./Divider";
+export * from "./Spacer";

--- a/packages/types/src/page/forms.ts
+++ b/packages/types/src/page/forms.ts
@@ -1,12 +1,22 @@
-export interface FormFieldOption {
-  label: string;
-  value: string;
-}
+import { z } from "zod";
 
-export interface FormField {
-  type: "text" | "email" | "select";
-  name?: string;
-  label?: string;
-  options?: FormFieldOption[];
-}
+export const formFieldOptionSchema = z
+  .object({
+    label: z.string(),
+    value: z.string(),
+  })
+  .strict();
+
+export type FormFieldOption = z.infer<typeof formFieldOptionSchema>;
+
+export const formFieldSchema = z
+  .object({
+    type: z.enum(["text", "email", "select"]),
+    name: z.string().optional(),
+    label: z.string().optional(),
+    options: z.array(formFieldOptionSchema).optional(),
+  })
+  .strict();
+
+export type FormField = z.infer<typeof formFieldSchema>;
 

--- a/packages/types/src/page/organisms/FeaturedProduct.ts
+++ b/packages/types/src/page/organisms/FeaturedProduct.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { baseComponentSchema, type PageComponentBase } from "../base";
+import { skuSchema } from "../../Product";
+
+const featuredProductSchema = skuSchema.extend({
+  badges: z
+    .object({
+      sale: z.boolean().optional(),
+      new: z.boolean().optional(),
+    })
+    .strict()
+    .optional(),
+});
+
+export type FeaturedProduct = z.infer<typeof featuredProductSchema>;
+
+export interface FeaturedProductComponent extends PageComponentBase {
+  type: "FeaturedProduct";
+  sku?: FeaturedProduct;
+  collectionId?: string;
+}
+
+export const featuredProductComponentSchema = baseComponentSchema.extend({
+  type: z.literal("FeaturedProduct"),
+  sku: featuredProductSchema.optional(),
+  collectionId: z.string().optional(),
+});
+

--- a/packages/types/src/page/organisms/FormBuilderBlock.ts
+++ b/packages/types/src/page/organisms/FormBuilderBlock.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { baseComponentSchema, type PageComponentBase } from "../base";
+import { formFieldSchema, type FormField } from "../forms";
+
+export interface FormBuilderBlockComponent extends PageComponentBase {
+  type: "FormBuilderBlock";
+  action?: string;
+  method?: string;
+  fields?: FormField[];
+  submitLabel?: string;
+}
+
+export const formBuilderBlockComponentSchema = baseComponentSchema.extend({
+  type: z.literal("FormBuilderBlock"),
+  action: z.string().optional(),
+  method: z.string().optional(),
+  fields: z.array(formFieldSchema).optional(),
+  submitLabel: z.string().optional(),
+});
+

--- a/packages/types/src/page/organisms/ProductBundle.ts
+++ b/packages/types/src/page/organisms/ProductBundle.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { baseComponentSchema, type PageComponentBase } from "../base";
+import { skuSchema, type SKU } from "../../Product";
+
+export interface ProductBundleComponent extends PageComponentBase {
+  type: "ProductBundle";
+  skus?: SKU[];
+  /** Percentage discount applied to the combined price */
+  discount?: number;
+  /** Quantity of bundles */
+  quantity?: number;
+}
+
+export const productBundleComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ProductBundle"),
+  skus: z.array(skuSchema).optional(),
+  discount: z.number().min(0).max(100).optional(),
+  quantity: z.number().int().min(1).optional(),
+});
+

--- a/packages/types/src/page/organisms/ProductComparison.ts
+++ b/packages/types/src/page/organisms/ProductComparison.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { baseComponentSchema, type PageComponentBase } from "../base";
+import { skuSchema, type SKU } from "../../Product";
+
+const skuAttributeSchema = skuSchema.keyof();
+
+export interface ProductComparisonComponent extends PageComponentBase {
+  type: "ProductComparison";
+  skus?: SKU[];
+  attributes?: Array<keyof SKU>;
+}
+
+export const productComparisonComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ProductComparison"),
+  skus: z.array(skuSchema).optional(),
+  attributes: z.array(skuAttributeSchema).optional(),
+});
+

--- a/packages/types/src/page/organisms/ProductFilter.ts
+++ b/packages/types/src/page/organisms/ProductFilter.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { baseComponentSchema, type PageComponentBase } from "../base";
+
+export interface ProductFilterComponent extends PageComponentBase {
+  type: "ProductFilter";
+  showSize?: boolean;
+  showColor?: boolean;
+  showPrice?: boolean;
+}
+
+export const productFilterComponentSchema = baseComponentSchema.extend({
+  type: z.literal("ProductFilter"),
+  showSize: z.boolean().optional(),
+  showColor: z.boolean().optional(),
+  showPrice: z.boolean().optional(),
+});
+

--- a/packages/types/src/page/organisms/index.ts
+++ b/packages/types/src/page/organisms/index.ts
@@ -14,4 +14,9 @@ export * from "./TestimonialSlider";
 export * from "./GiftCardBlock";
 export * from "./PopupModal";
 export * from "./CollectionList";
+export * from "./FeaturedProduct";
+export * from "./ProductComparison";
+export * from "./FormBuilderBlock";
+export * from "./ProductBundle";
+export * from "./ProductFilter";
 

--- a/packages/types/src/page/page.ts
+++ b/packages/types/src/page/page.ts
@@ -6,6 +6,8 @@ import {
   textComponentSchema,
   customHtmlComponentSchema,
   buttonComponentSchema,
+  dividerComponentSchema,
+  spacerComponentSchema,
 } from "./atoms";
 import {
   announcementBarComponentSchema,
@@ -39,6 +41,11 @@ import {
   giftCardBlockComponentSchema,
   popupModalComponentSchema,
   collectionListComponentSchema,
+  featuredProductComponentSchema,
+  productComparisonComponentSchema,
+  formBuilderBlockComponentSchema,
+  productBundleComponentSchema,
+  productFilterComponentSchema,
 } from "./organisms";
 import {
   headerComponentSchema,
@@ -81,10 +88,17 @@ export const pageComponentSchema = z.lazy(() =>
     giftCardBlockComponentSchema,
     popupModalComponentSchema,
     testimonialSliderComponentSchema,
+    featuredProductComponentSchema,
+    productComparisonComponentSchema,
+    formBuilderBlockComponentSchema,
+    productBundleComponentSchema,
+    productFilterComponentSchema,
     imageComponentSchema,
     textComponentSchema,
     customHtmlComponentSchema,
     buttonComponentSchema,
+    dividerComponentSchema,
+    spacerComponentSchema,
     sectionComponentSchema,
     multiColumnComponentSchema,
     tabsComponentSchema,


### PR DESCRIPTION
## Summary
- add zod schemas for the missing Divider/Spacer atom blocks and newer page builder organism blocks such as FeaturedProduct, ProductBundle, ProductComparison, ProductFilter, and FormBuilderBlock
- expose reusable zod schemas for page builder form fields and wire the new components into the page component discriminated union so PageBuilder history parsing accepts them

## Testing
- pnpm --filter @acme/ui exec jest --config ../../jest.config.cjs --runInBand --detectOpenHandles --no-coverage packages/ui/__tests__/PageBuilder.autoSave.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cd624c85d0832fadfd46ca021d7d61