### PR TITLE
Update CMS new page copy and contrast tokens

### DIFF
--- a/docs/cms.md
+++ b/docs/cms.md
@@ -12,7 +12,7 @@ The sidebar inside the CMS provides quick access to different sections:
 
 - **Dashboard** – Shows shop statistics and pending account requests.
 - **Products** – Lists all products. If a shop is selected, also shows **New Product**.
-- **Pages** – Lists pages for the current shop with a **New Page** link when a shop is selected.
+- **Pages** – Lists pages for the current shop with a **Create new page** link when a shop is selected.
 - **Media** – Upload and manage media files.
 - **Theme** – Customize the shop's appearance. Visible to admins and shop owners. See [advanced theming](./theming-advanced.md) for base themes, overrides, persistence and live preview.
 - **Settings** – Shop settings. When a shop is active an additional **SEO** option appears.
@@ -21,7 +21,7 @@ The sidebar inside the CMS provides quick access to different sections:
 - **Account Requests** – (Admin only) Approve new user accounts.
 - **Create Shop** – (Admin only) Launch the configurator for creating a new shop.
 
-Links such as **New Product**, **New Page** and **SEO** only appear after picking a shop, otherwise they are hidden.
+Links such as **New Product**, **Create new page** and **SEO** only appear after picking a shop, otherwise they are hidden.
 
 ## Switching Shops
 

--- a/packages/ui/__tests__/PagesTable.client.test.tsx
+++ b/packages/ui/__tests__/PagesTable.client.test.tsx
@@ -33,17 +33,17 @@ describe("PagesTable", () => {
     expect(screen.getByText("Status")).toBeInTheDocument();
     expect(screen.queryByText("Actions")).not.toBeInTheDocument();
 
-    expect(screen.getByText("about")).toBeInTheDocument();
+    expect(screen.getByText(/about/)).toBeInTheDocument();
     expect(screen.getByText("draft")).toBeInTheDocument();
 
-    expect(screen.queryByText("New Page")).not.toBeInTheDocument();
+    expect(screen.queryByText("Create new page")).not.toBeInTheDocument();
     expect(screen.queryByText("Edit")).not.toBeInTheDocument();
   });
 
   it("shows action buttons when write access is enabled", () => {
     render(<PagesTable shop="acme" pages={pages} canWrite />);
 
-    expect(screen.getByText("New Page")).toBeInTheDocument();
+    expect(screen.getByText("Create new page")).toBeInTheDocument();
     expect(screen.getByText("Actions")).toBeInTheDocument();
 
     const editLinks = screen.getAllByRole("link", { name: "Edit" });

--- a/packages/ui/__tests__/colorUtils.test.ts
+++ b/packages/ui/__tests__/colorUtils.test.ts
@@ -43,16 +43,16 @@ describe("hexToRgb", () => {
 });
 
 describe("getContrastColor", () => {
-  it("returns black for light colors", () => {
-    expect(getContrastColor("#ffffff")).toBe("#000000");
+  it("returns foreground token for light colors", () => {
+    expect(getContrastColor("#ffffff")).toBe("var(--color-fg)");
   });
 
-  it("returns white for dark colors", () => {
-    expect(getContrastColor("#000000")).toBe("#ffffff");
+  it("returns background token for dark colors", () => {
+    expect(getContrastColor("#000000")).toBe("var(--color-bg)");
   });
 
   it("handles high-contrast colors", () => {
-    expect(getContrastColor("#ff0000")).toBe("#ffffff");
+    expect(getContrastColor("#ff0000")).toBe("var(--color-bg)");
   });
 
   it("throws on invalid hex", () => {

--- a/packages/ui/src/components/cms/Sidebar.client.tsx
+++ b/packages/ui/src/components/cms/Sidebar.client.tsx
@@ -54,7 +54,7 @@ function Sidebar({
         : []),
       { href: shop ? `${base}/pages` : "/pages", label: "Pages", icon: "📄" },
       ...(shop
-        ? [{ href: `${base}/pages/new/builder`, label: "New Page", icon: "📝" }]
+        ? [{ href: `${base}/pages/new/builder`, label: "Create new page", icon: "📝" }]
         : []),
       { href: shop ? `${base}/media` : "/media", label: "Media", icon: "🖼️" },
       ...(shop

--- a/packages/ui/src/components/cms/__tests__/PagesTable.client.test.tsx
+++ b/packages/ui/src/components/cms/__tests__/PagesTable.client.test.tsx
@@ -35,7 +35,7 @@ describe("PagesTable", () => {
       .map((h) => h.textContent?.trim());
     expect(headers).toEqual(["Slug", "Status"]);
     expect(
-      screen.queryByRole("link", { name: "New Page" })
+      screen.queryByRole("link", { name: "Create new page" })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Edit" })
@@ -45,7 +45,7 @@ describe("PagesTable", () => {
   it("shows new page and edit links when writable", () => {
     render(<PagesTable shop={shop} pages={pages} canWrite />);
 
-    const newPageLink = screen.getByRole("link", { name: "New Page" });
+    const newPageLink = screen.getByRole("link", { name: "Create new page" });
     expect(newPageLink).toHaveAttribute(
       "href",
       `/cms/shop/${shop}/pages/new/builder`
@@ -71,7 +71,9 @@ describe("PagesTable", () => {
       .map((h) => h.textContent?.trim());
     expect(headers).toEqual(["Slug", "Status", "Actions"]);
 
-    expect(screen.getByRole("link", { name: "New Page" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Create new page" })
+    ).toBeInTheDocument();
 
     expect(dataTableSpy).toHaveBeenCalled();
     const props = dataTableSpy.mock.calls[0][0];

--- a/packages/ui/src/utils/__tests__/colorUtils.test.ts
+++ b/packages/ui/src/utils/__tests__/colorUtils.test.ts
@@ -55,10 +55,10 @@ describe("colorUtils", () => {
     expect(() => hexToRgb("not-a-hex" as any)).toThrow("Invalid hex color");
   });
 
-  test("getContrastColor chooses black or white based on brightness", () => {
-    expect(getContrastColor("#ffffff")).toBe("#000000");
-    expect(getContrastColor("#000000")).toBe("#ffffff");
-    expect(getContrastColor("#777777")).toBe("#ffffff");
+  test("getContrastColor returns themed tokens based on brightness", () => {
+    expect(getContrastColor("#ffffff")).toBe("var(--color-fg)");
+    expect(getContrastColor("#000000")).toBe("var(--color-bg)");
+    expect(getContrastColor("#777777")).toBe("var(--color-bg)");
   });
 
   test("hexToHsl handles black and invalid input", () => {

--- a/packages/ui/src/utils/colorUtils.d.ts
+++ b/packages/ui/src/utils/colorUtils.d.ts
@@ -4,6 +4,6 @@ export declare function isHex(value: string): boolean;
 export declare function isHsl(value: string): boolean;
 export declare function hslToHex(hsl: string): string;
 export declare function hexToRgb(hex: string): [number, number, number];
-export declare function getContrastColor(hex: string): "#000000" | "#ffffff";
+export declare function getContrastColor(hex: string): "var(--color-fg)" | "var(--color-bg)";
 export declare function hexToHsl(hex: string): string;
 //# sourceMappingURL=colorUtils.d.ts.map

--- a/packages/ui/src/utils/colorUtils.ts
+++ b/packages/ui/src/utils/colorUtils.ts
@@ -57,10 +57,10 @@ export function hexToRgb(hex: string): [number, number, number] {
 
 export function getContrastColor(
   hex: string,
-): "#000000" | "#ffffff" {
+): "var(--color-fg)" | "var(--color-bg)" {
   const [r, g, b] = hexToRgb(hex);
   const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-  return brightness > 186 ? "#000000" : "#ffffff";
+  return brightness > 186 ? "var(--color-fg)" : "var(--color-bg)";
 }
 
 export function hexToHsl(hex: string): string {


### PR DESCRIPTION
## Summary
- align CMS copy with the new "Create new page" label across sidebar, docs, and table tests
- switch `getContrastColor` to return themed CSS variables instead of raw hex strings
- refresh associated unit tests to cover the updated copy and contrast helpers

## Testing
- pnpm exec jest packages/ui/src/components/cms/__tests__/PagesTable.client.test.tsx packages/ui/__tests__/PagesTable.client.test.tsx packages/ui/__tests__/colorUtils.test.ts packages/ui/src/utils/__tests__/colorUtils.test.ts --runTestsByPath --coverage=false --runInBand --verbose


------
https://chatgpt.com/codex/tasks/task_e_68cd67830318832f9a1bad5b09e73e16