### PR TITLE
feat: add search to pages panel

### DIFF
--- a/packages/ui/__tests__/PagesTable.client.test.tsx
+++ b/packages/ui/__tests__/PagesTable.client.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import PagesTable from "../src/components/cms/PagesTable";
 import type { Page } from "@acme/types";
 
@@ -48,5 +49,16 @@ describe("PagesTable", () => {
 
     const editLinks = screen.getAllByRole("link", { name: "Edit" });
     expect(editLinks).toHaveLength(pages.length);
+  });
+
+  it("filters pages by search query", async () => {
+    const user = userEvent.setup();
+    render(<PagesTable shop="acme" pages={pages} />);
+
+    const searchInput = screen.getByRole("searchbox", { name: "Search pages" });
+    await user.type(searchInput, "contact");
+
+    expect(screen.getByText(/contact/)).toBeInTheDocument();
+    expect(screen.queryByText(/about/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add client-side filtering to the CMS pages table
- expose a search field in the table header so editors can filter by slug, title, or status
- cover the new filtering behaviour with a user-interaction test

## Testing
- `pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/__tests__/PagesTable.client.test.tsx` *(fails: Invalid package.json in package.json)*
- `pnpm run check:references` *(fails: Invalid package.json in package.json)*
- `pnpm run build:ts` *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b1ee5f0832fa333e095dc6d8c1d