### PR TITLE
feat(ui): use chevron icons for inspector toggle

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilderLayout.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilderLayout.tsx
@@ -34,7 +34,7 @@ import PresenceAvatars from "./PresenceAvatars";
 import NotificationsBell from "./NotificationsBell";
 import AppMarketStub from "./AppMarketStub";
 import StudioMenu from "./StudioMenu";
-import { CheckIcon, ReloadIcon } from "@radix-ui/react-icons";
+import { CheckIcon, ReloadIcon, ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons";
 
 interface LayoutProps {
   style?: CSSProperties;
@@ -227,12 +227,16 @@ const PageBuilderLayout = ({
           <HistoryControls {...historyProps} />
           <button
             type="button"
-            className="rounded border px-2 py-1 text-sm"
+            className="inline-flex items-center justify-center rounded border px-2 py-1 text-sm"
             onClick={() => setShowInspector((v) => !v)}
             aria-label={showInspector ? "Hide Inspector" : "Show Inspector"}
             title={showInspector ? "Hide Inspector" : "Show Inspector"}
           >
-            {showInspector ? <span className="inline-flex items-center" aria-hidden>›</span> : <span className="inline-flex items-center" aria-hidden>‹</span>}
+            {showInspector ? (
+              <ChevronRightIcon aria-hidden="true" className="h-4 w-4" />
+            ) : (
+              <ChevronLeftIcon aria-hidden="true" className="h-4 w-4" />
+            )}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the inspector toggle glyph with Radix chevron icons to match the design system
- keep the existing aria-label and title while centering the new icon within the control

## Testing
- corepack pnpm --filter @acme/ui lint *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b04018c832f8a7affef3647559a