### PR TITLE
feat: gate palette categories by installed apps

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilderLayout.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilderLayout.tsx
@@ -284,7 +284,12 @@ const PageBuilderLayout = ({
             }
           >
             {dragMeta ? (
-              <DragOverlayPreview dragMeta={dragMeta} allowed={dropAllowed ?? null} locale={(toolbarProps as any)?.locale ?? 'en'} />
+              <DragOverlayPreview
+                dragMeta={dragMeta}
+                allowed={dropAllowed ?? null}
+                locale={(toolbarProps as any)?.locale ?? 'en'}
+                shop={shop ?? null}
+              />
             ) : activeType ? (
               <div className="pointer-events-none rounded border bg-muted px-4 py-2 opacity-50 shadow">{activeType}</div>
             ) : null}

--- a/packages/ui/src/components/cms/page-builder/appInstallStore.ts
+++ b/packages/ui/src/components/cms/page-builder/appInstallStore.ts
@@ -1,0 +1,132 @@
+const STORAGE_KEY = "pb:installed-apps";
+const GLOBAL_KEY = "__global__";
+
+export const INSTALLED_APPS_EVENT = "pb:installed-apps-change";
+
+export interface InstalledAppsChangeDetail {
+  shop: string | null;
+  apps: string[];
+}
+
+type StorageShape = Record<string, string[]>;
+
+type MaybeWindow = typeof window | undefined;
+
+const getWindow = (): MaybeWindow => (typeof window !== "undefined" ? window : undefined);
+
+const readStorage = (): StorageShape => {
+  const w = getWindow();
+  if (!w?.localStorage) return {};
+  try {
+    const raw = w.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return {};
+    return Object.keys(parsed as Record<string, unknown>).reduce<StorageShape>((acc, key) => {
+      const value = (parsed as Record<string, unknown>)[key];
+      if (Array.isArray(value)) {
+        acc[key] = value.filter((item): item is string => typeof item === "string");
+      }
+      return acc;
+    }, {});
+  } catch {
+    return {};
+  }
+};
+
+const writeStorage = (data: StorageShape): void => {
+  const w = getWindow();
+  if (!w?.localStorage) return;
+  try {
+    if (Object.keys(data).length === 0) {
+      w.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      w.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    }
+  } catch {
+    // ignore write failures (private mode, quota exceeded, etc.)
+  }
+};
+
+const normalizeShop = (shop?: string | null): string => (shop ? shop : GLOBAL_KEY);
+
+const dispatchChange = (shop: string | null, apps: string[]): void => {
+  const w = getWindow();
+  if (!w) return;
+  try {
+    const event = new CustomEvent<InstalledAppsChangeDetail>(INSTALLED_APPS_EVENT, {
+      detail: { shop, apps: [...apps] },
+    });
+    w.dispatchEvent(event);
+  } catch {
+    // no-op if CustomEvent fails (older browsers)
+  }
+};
+
+const saveApps = (shop: string | null, apps: string[]): void => {
+  const key = normalizeShop(shop);
+  const trimmed = apps.filter((appId) => typeof appId === "string" && appId.trim().length > 0);
+  const deduped = Array.from(new Set(trimmed));
+  const storage = readStorage();
+  if (deduped.length === 0) {
+    delete storage[key];
+  } else {
+    storage[key] = deduped;
+  }
+  writeStorage(storage);
+  dispatchChange(shop, deduped);
+};
+
+export const listInstalledApps = (shop?: string | null): string[] => {
+  const key = normalizeShop(shop ?? null);
+  const storage = readStorage();
+  return [...(storage[key] ?? [])];
+};
+
+export const setInstalledApps = (shop: string | null, apps: string[]): void => {
+  saveApps(shop, apps);
+};
+
+export const installApp = (shop: string | null, appId: string): string[] => {
+  const current = listInstalledApps(shop);
+  if (!appId || current.includes(appId)) {
+    return current;
+  }
+  const next = [...current, appId];
+  saveApps(shop, next);
+  return next;
+};
+
+export const uninstallApp = (shop: string | null, appId: string): string[] => {
+  const current = listInstalledApps(shop);
+  const next = current.filter((id) => id !== appId);
+  saveApps(shop, next);
+  return next;
+};
+
+export const subscribeInstalledApps = (
+  shop: string | null,
+  callback: (apps: string[]) => void,
+): (() => void) => {
+  const w = getWindow();
+  if (!w) return () => {};
+
+  const targetShop = shop ?? null;
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<InstalledAppsChangeDetail>).detail;
+    if (!detail) return;
+    if ((detail.shop ?? null) !== targetShop) return;
+    callback([...detail.apps]);
+  };
+
+  w.addEventListener(INSTALLED_APPS_EVENT, handler as EventListener);
+  return () => w.removeEventListener(INSTALLED_APPS_EVENT, handler as EventListener);
+};
+
+export const clearInstalledApps = (shop?: string | null): void => {
+  const key = normalizeShop(shop ?? null);
+  const storage = readStorage();
+  delete storage[key];
+  writeStorage(storage);
+  dispatchChange(shop ?? null, []);
+};

--- a/packages/ui/src/components/cms/page-builder/paletteData.ts
+++ b/packages/ui/src/components/cms/page-builder/paletteData.ts
@@ -10,11 +10,11 @@ import type { BlockRegistryEntry } from "../blocks/types";
 import type { PaletteMeta } from "./palette.types";
 import type { ComponentType } from "./defaults";
 
-const defaultIcon = "/window.svg";
+export const defaultIcon = "/window.svg";
 
-type PaletteRegistry = Record<string, BlockRegistryEntry<unknown> & { description?: string }>;
+export type PaletteRegistry = Record<string, BlockRegistryEntry<unknown> & { description?: string }>;
 
-const createPaletteItems = (registry: PaletteRegistry): PaletteMeta[] =>
+export const createPaletteItems = (registry: PaletteRegistry): PaletteMeta[] =>
   (Object.keys(registry) as ComponentType[])
     .sort()
     .map((t) => ({
@@ -35,4 +35,123 @@ export const palette = {
 } as const;
 
 export type PaletteCategories = keyof typeof palette;
+
+export type PaletteCategoryDefinition = {
+  id: string;
+  label: string;
+  order: number;
+  items: PaletteMeta[];
+};
+
+type MutableCategory = {
+  id: string;
+  label?: string;
+  order?: number;
+  items: PaletteMeta[];
+};
+
+const normalizeItems = (items: PaletteMeta[]): PaletteMeta[] =>
+  items.map((item) => ({
+    ...item,
+    icon: item.icon ?? item.previewImage ?? defaultIcon,
+    previewImage: item.previewImage ?? item.icon ?? defaultIcon,
+  }));
+
+const BASE_CATEGORY_ENTRIES: PaletteCategoryDefinition[] = (
+  Object.entries(palette) as [string, PaletteMeta[]][]
+).map(([id, items], index) => ({
+  id,
+  label: id,
+  order: index,
+  items: normalizeItems(items),
+}));
+
+const appPaletteRegistry = new Map<string, MutableCategory[]>();
+
+export type AppPaletteCategory = {
+  id: string;
+  label?: string;
+  order?: number;
+  items: PaletteMeta[];
+};
+
+export const registerAppPalette = (appId: string, categories: AppPaletteCategory[]): void => {
+  appPaletteRegistry.set(
+    appId,
+    categories.map((category) => ({
+      id: category.id,
+      label: category.label ?? category.id,
+      order: category.order,
+      items: normalizeItems(category.items),
+    })),
+  );
+};
+
+export const unregisterAppPalette = (appId: string): void => {
+  appPaletteRegistry.delete(appId);
+};
+
+const mergeAppCategories = (installedApps: Iterable<string>): PaletteCategoryDefinition[] => {
+  const merged = new Map<string, MutableCategory>();
+
+  for (const appId of installedApps) {
+    const categories = appPaletteRegistry.get(appId);
+    if (!categories) continue;
+
+    for (const category of categories) {
+      const existing = merged.get(category.id);
+      if (!existing) {
+        merged.set(category.id, {
+          id: category.id,
+          label: category.label ?? category.id,
+          order: category.order,
+          items: [...category.items],
+        });
+        continue;
+      }
+
+      const existingTypes = new Set(existing.items.map((item) => item.type));
+      const nextItems = [...existing.items];
+      for (const item of category.items) {
+        if (!existingTypes.has(item.type)) {
+          nextItems.push(item);
+          existingTypes.add(item.type);
+        }
+      }
+
+      merged.set(category.id, {
+        id: existing.id,
+        label: existing.label ?? category.label ?? category.id,
+        order: existing.order ?? category.order,
+        items: nextItems,
+      });
+    }
+  }
+
+  return Array.from(merged.values()).map((category) => ({
+    id: category.id,
+    label: category.label ?? category.id,
+    order: category.order ?? BASE_CATEGORY_ENTRIES.length,
+    items: normalizeItems(category.items),
+  }));
+};
+
+export const getPaletteCategories = (installedApps: Iterable<string>): PaletteCategoryDefinition[] => {
+  const dynamic = mergeAppCategories(installedApps);
+  return [...BASE_CATEGORY_ENTRIES.map((category) => ({ ...category, items: [...category.items] })), ...dynamic]
+    .filter((category) => category.items.length > 0)
+    .sort((a, b) => {
+      if (a.order === b.order) return a.label.localeCompare(b.label);
+      return a.order - b.order;
+    });
+};
+
+export const getPaletteMap = (installedApps: Iterable<string>): Record<string, PaletteMeta[]> => {
+  const map: Record<string, PaletteMeta[]> = {};
+  for (const category of getPaletteCategories(installedApps)) {
+    map[category.id] = category.items;
+  }
+  return map;
+};
+
 


### PR DESCRIPTION
## Summary
- add an app installation store to persist shop-specific app selections and emit change events
- allow palette data to register and merge app-provided categories and expose helpers for filtering installed apps
- update the palette UI and drag overlay preview to subscribe to installed apps and show app sections only when available

## Testing
- `pnpm --filter @acme/ui build` *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d19af68eb0832fb9af30d34221920a