### PR TITLE
Ensure only one pinned global per page

### DIFF
--- a/packages/types/src/page/page.ts
+++ b/packages/types/src/page/page.ts
@@ -136,7 +136,7 @@ export interface EditorFlags {
   /** Per-node custom mobile order (used when stackStrategy = custom on parent) */
   orderMobile?: number;
   /** Builder-only metadata for global (linked) components */
-  global?: { id: string; overrides?: unknown };
+  global?: { id: string; overrides?: unknown; pinned?: boolean };
 }
 
 export interface HistoryState {
@@ -174,6 +174,7 @@ export const historyStateSchema = z
             .object({
               id: z.string(),
               overrides: z.unknown().optional(),
+              pinned: z.boolean().optional(),
             })
             .optional(),
         })

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection.tsx
@@ -106,6 +106,24 @@ const PageSidebarSingleSelection = ({ components, selectedIds, dispatch, editor,
     return g?.label || gid;
   })();
 
+  React.useEffect(() => {
+    if (!eid?.global?.pinned) return;
+
+    const otherPinned = Object.entries(editor ?? {}).filter(
+      ([id, flags]) => id !== selectedComponent.id && Boolean((flags as any)?.global?.pinned),
+    );
+
+    if (otherPinned.length === 0) return;
+
+    otherPinned.forEach(([id, flags]) => {
+      const otherGlobal = (flags as any)?.global;
+      if (!otherGlobal) return;
+
+      const nextGlobal = { ...otherGlobal, pinned: false };
+      dispatch({ type: "update-editor", id, patch: { global: nextGlobal } as any });
+    });
+  }, [dispatch, editor, selectedComponent.id, eid?.global?.pinned]);
+
   return (
     <div className="space-y-2">
       {/* Alignment / distribution row (multi-select) */}

--- a/packages/ui/src/components/cms/page-builder/state/layout/types.ts
+++ b/packages/ui/src/components/cms/page-builder/state/layout/types.ts
@@ -16,6 +16,11 @@ export type EditorFlags = {
   orderDesktop?: number;
   orderTablet?: number;
   orderMobile?: number;
+  global?: {
+    id: string;
+    overrides?: unknown;
+    pinned?: boolean;
+  };
 };
 
 export type AddAction = {


### PR DESCRIPTION
## Summary
- allow global editor metadata to track a pinned flag in the shared types
- expose the pinned metadata on editor flags used by the page builder
- ensure toggling a pinned global unpins any other pinned entries on the page

## Testing
- npx tsc -p packages/types/tsconfig.json *(fails: missing type definitions in the environment)*
- npx tsc -p packages/ui/tsconfig.json *(fails: missing type definitions in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19b2bb234832f95f7424994fa2b29