### PR TITLE
Persist global editing width per viewport

### DIFF
--- a/packages/types/src/page/page.ts
+++ b/packages/types/src/page/page.ts
@@ -136,7 +136,12 @@ export interface EditorFlags {
   /** Per-node custom mobile order (used when stackStrategy = custom on parent) */
   orderMobile?: number;
   /** Builder-only metadata for global (linked) components */
-  global?: { id: string; overrides?: unknown };
+  global?: {
+    id: string;
+    overrides?: unknown;
+    /** Preferred editing widths per viewport (builder-only) */
+    editingWidth?: Partial<Record<"desktop" | "tablet" | "mobile", number>>;
+  };
 }
 
 export interface HistoryState {
@@ -174,6 +179,14 @@ export const historyStateSchema = z
             .object({
               id: z.string(),
               overrides: z.unknown().optional(),
+              editingWidth: z
+                .object({
+                  desktop: z.number().int().nonnegative().optional(),
+                  tablet: z.number().int().nonnegative().optional(),
+                  mobile: z.number().int().nonnegative().optional(),
+                })
+                .partial()
+                .optional(),
             })
             .optional(),
         })

--- a/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilder.tsx
@@ -24,6 +24,7 @@ interface Props {
   onChange?: (components: PageComponent[]) => void; style?: CSSProperties;
   presetsSourceUrl?: string;
   pagesNav?: { items: { label: string; value: string; href: string }[]; current: string };
+  globalContext?: { id: string } | null;
 }
 
 const PageBuilder = memo(function PageBuilder({
@@ -39,6 +40,7 @@ const PageBuilder = memo(function PageBuilder({
   style,
   presetsSourceUrl,
   pagesNav,
+  globalContext = null,
 }: Props) {
   const pathname = usePathname() ?? "";
   const shop = useMemo(() => getShopFromPath(pathname), [pathname]);
@@ -55,7 +57,7 @@ const PageBuilder = memo(function PageBuilder({
     onRotateDevice: (d) => rotateDeviceRef.current(d),
   });
 
-  const controls = usePageBuilderControls({ state, dispatch });
+  const controls = usePageBuilderControls({ state, dispatch, globalContext });
   togglePreviewRef.current = controls.togglePreview;
   rotateDeviceRef.current = controls.rotateDevice;
 

--- a/packages/ui/src/components/cms/page-builder/state/history.schema.ts
+++ b/packages/ui/src/components/cms/page-builder/state/history.schema.ts
@@ -18,6 +18,20 @@ const editorFlagsSchema = z.object({
   orderDesktop: z.number().int().nonnegative().optional(),
   orderTablet: z.number().int().nonnegative().optional(),
   orderMobile: z.number().int().nonnegative().optional(),
+  global: z
+    .object({
+      id: z.string(),
+      overrides: z.unknown().optional(),
+      editingWidth: z
+        .object({
+          desktop: z.number().int().nonnegative().optional(),
+          tablet: z.number().int().nonnegative().optional(),
+          mobile: z.number().int().nonnegative().optional(),
+        })
+        .partial()
+        .optional(),
+    })
+    .optional(),
 });
 
 export const historyStateSchema: z.ZodType<unknown> = z

--- a/packages/ui/src/components/cms/page-builder/state/layout/types.ts
+++ b/packages/ui/src/components/cms/page-builder/state/layout/types.ts
@@ -16,6 +16,11 @@ export type EditorFlags = {
   orderDesktop?: number;
   orderTablet?: number;
   orderMobile?: number;
+  global?: {
+    id: string;
+    overrides?: unknown;
+    editingWidth?: Partial<Record<"desktop" | "tablet" | "mobile", number>>;
+  };
 };
 
 export type AddAction = {


### PR DESCRIPTION
## Summary
- extend PageBuilder controls with optional global context and persist editing width per viewport via editor metadata
- expose global editing context on PageBuilder and update shared types/schemas to include per-viewport global editing widths
- add coverage ensuring global editing widths sync from history state and dispatch updates

## Testing
- ⚠️ `pnpm --filter @acme/ui test -- usePageBuilderControls.extra` *(fails: repository root package.json is invalid in this environment, preventing pnpm commands)*

------
https://chatgpt.com/codex/tasks/task_e_68d19ae3106c832fb27567a45a92ac80