### PR TITLE
feat: replace page builder preview toggle with icon button

### DIFF
--- a/packages/ui/src/components/cms/page-builder/PageBuilderLayout.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilderLayout.tsx
@@ -3,7 +3,7 @@
 import { DndContext, DragOverlay, defaultDropAnimation, defaultDropAnimationSideEffects } from "@dnd-kit/core";
 import type { CSSProperties, ComponentProps } from "react";
 import React from "react";
-import { Toast } from "../../atoms";
+import { IconButton, Toast } from "../../atoms";
 import PageToolbar from "./PageToolbar";
 import PageCanvas from "./PageCanvas";
 import PageSidebar from "./PageSidebar";
@@ -34,7 +34,14 @@ import PresenceAvatars from "./PresenceAvatars";
 import NotificationsBell from "./NotificationsBell";
 import AppMarketStub from "./AppMarketStub";
 import StudioMenu from "./StudioMenu";
-import { CheckIcon, ReloadIcon, ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons";
+import {
+  CheckIcon,
+  ReloadIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  EyeClosedIcon,
+  EyeOpenIcon,
+} from "@radix-ui/react-icons";
 
 interface LayoutProps {
   style?: CSSProperties;
@@ -215,14 +222,21 @@ const PageBuilderLayout = ({
             onParentFirstChange={onParentFirstChange}
           />
           <PresenceAvatars shop={shop ?? null} pageId={pageId ?? null} />
-          <button
+          <IconButton
             type="button"
-            className="rounded border px-2 py-1 text-sm"
+            aria-label={showPreview ? "Exit preview" : "Preview"}
+            title={showPreview ? "Exit preview" : "Preview"}
             onClick={togglePreview}
-            aria-label="Preview"
+            aria-pressed={showPreview}
+            variant={showPreview ? "secondary" : "ghost"}
+            className="border border-input"
           >
-            {showPreview ? "Editing" : "Preview"}
-          </button>
+            {showPreview ? (
+              <EyeOpenIcon aria-hidden="true" className="h-4 w-4" />
+            ) : (
+              <EyeClosedIcon aria-hidden="true" className="h-4 w-4" />
+            )}
+          </IconButton>
           <NotificationsBell shop={shop ?? null} pageId={pageId ?? null} />
           <HistoryControls {...historyProps} />
           <button


### PR DESCRIPTION
## Summary
- replace the text-only preview toggle with the design system IconButton
- add eye icons that reflect whether preview mode is active

## Testing
- pnpm run check:references *(fails: Invalid package.json in package.json)*
- pnpm run build:ts *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d19e993cd0832f830d383873d24557