### PR TITLE
Expose text themes in palette and style panel

### DIFF
--- a/packages/i18n/src/de.json
+++ b/packages/i18n/src/de.json
@@ -49,6 +49,7 @@
   "cms.style.fontSize": "Schriftgröße",
   "cms.style.fontWeight": "Schriftstärke",
   "cms.style.lineHeight": "Zeilenhöhe",
+  "cms.style.textStyle": "Textstil",
   "cms.style.colorPlaceholder": "Token oder #Hex",
   "cms.image.url": "Bild-URL",
   "cms.image.upload": "Hochladen",

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -45,6 +45,7 @@
   "cms.style.fontSize": "Font Size",
   "cms.style.fontWeight": "Font Weight",
   "cms.style.lineHeight": "Line Height",
+  "cms.style.textStyle": "Text Style",
   "cms.style.colorPlaceholder": "token or #hex",
   "cms.image.url": "Image URL",
   "cms.image.upload": "Upload",

--- a/packages/i18n/src/it.json
+++ b/packages/i18n/src/it.json
@@ -49,6 +49,7 @@
   "cms.style.fontSize": "Dimensione carattere",
   "cms.style.fontWeight": "Peso carattere",
   "cms.style.lineHeight": "Altezza linea",
+  "cms.style.textStyle": "Stile del testo",
   "cms.style.colorPlaceholder": "token o #hex",
   "cms.image.url": "URL immagine",
   "cms.image.upload": "Carica",

--- a/packages/ui/src/components/cms/page-builder/__tests__/textThemes.test.ts
+++ b/packages/ui/src/components/cms/page-builder/__tests__/textThemes.test.ts
@@ -1,0 +1,74 @@
+import {
+  applyTextThemeToOverrides,
+  clearTextThemeFromOverrides,
+  extractTextThemes,
+  getAppliedTextTheme,
+  toCssValue,
+} from "../textThemes";
+
+describe("textThemes", () => {
+  const sampleTokens = {
+    "--text-heading-font-size": "32px",
+    "--text-heading-line-height": "40px",
+    "--text-heading-font-weight": "700",
+    "--text-heading-font-family": "var(--font-heading)",
+    "--text-heading-font-size-desktop": "36px",
+    "--text-heading-line-height-desktop": "42px",
+    "--text-heading-font-size-tablet": "34px",
+    "--text-heading-line-height-tablet": "40px",
+    "--text-body-font-size": "16px",
+    "--text-body-line-height": "24px",
+    "--text-body-font-weight": "400",
+    "--typography-body-font-family": "var(--font-body)",
+  } as Record<string, string>;
+
+  it("extracts themes from token map", () => {
+    const themes = extractTextThemes(sampleTokens);
+    expect(themes).toHaveLength(2);
+    expect(themes[0].id).toBe("body");
+    expect(themes[0].label).toBe("Body");
+    expect(themes[0].tokens.typography).toEqual({
+      fontSize: "--text-body-font-size",
+      lineHeight: "--text-body-line-height",
+      fontWeight: "--text-body-font-weight",
+      fontFamily: "--typography-body-font-family",
+    });
+    expect(themes[1].tokens.typographyDesktop).toEqual({
+      fontSize: "--text-heading-font-size-desktop",
+      lineHeight: "--text-heading-line-height-desktop",
+    });
+  });
+
+  it("applies a theme to overrides", () => {
+    const [bodyTheme] = extractTextThemes(sampleTokens);
+    const next = applyTextThemeToOverrides(undefined, bodyTheme);
+    expect(next.typography).toEqual({
+      fontSize: "--text-body-font-size",
+      lineHeight: "--text-body-line-height",
+      fontWeight: "--text-body-font-weight",
+      fontFamily: "--typography-body-font-family",
+    });
+  });
+
+  it("clears typography overrides", () => {
+    const [bodyTheme, headingTheme] = extractTextThemes(sampleTokens);
+    let next = applyTextThemeToOverrides(undefined, headingTheme);
+    next = applyTextThemeToOverrides(next, bodyTheme);
+    const cleared = clearTextThemeFromOverrides(next);
+    expect(cleared.typography).toBeUndefined();
+    expect(cleared.typographyDesktop).toBeUndefined();
+  });
+
+  it("detects the currently applied theme", () => {
+    const themes = extractTextThemes(sampleTokens);
+    const overrides = applyTextThemeToOverrides(undefined, themes[1]);
+    const active = getAppliedTextTheme(overrides, themes);
+    expect(active?.id).toBe("heading");
+  });
+
+  it("normalises CSS values when building previews", () => {
+    expect(toCssValue("--text-body-font-size")).toBe("var(--text-body-font-size)");
+    expect(toCssValue("700")).toBe("700");
+    expect(toCssValue(undefined)).toBeUndefined();
+  });
+});

--- a/packages/ui/src/components/cms/page-builder/textThemes.ts
+++ b/packages/ui/src/components/cms/page-builder/textThemes.ts
@@ -1,0 +1,234 @@
+import type { StyleOverrides } from "@acme/types/style/StyleOverrides";
+
+export type TextThemeGroupKey =
+  | "typography"
+  | "typographyDesktop"
+  | "typographyTablet"
+  | "typographyMobile";
+
+type TypographyProp = "fontFamily" | "fontSize" | "fontWeight" | "lineHeight";
+type BreakpointProp = "fontSize" | "lineHeight";
+
+type TextThemeTokens = {
+  typography?: Partial<Record<TypographyProp, string>>;
+  typographyDesktop?: Partial<Record<BreakpointProp, string>>;
+  typographyTablet?: Partial<Record<BreakpointProp, string>>;
+  typographyMobile?: Partial<Record<BreakpointProp, string>>;
+};
+
+export interface TextTheme {
+  id: string;
+  label: string;
+  tokens: TextThemeTokens;
+}
+
+const PROP_KEYS: Record<string, TypographyProp | BreakpointProp> = {
+  fontfamily: "fontFamily",
+  fontface: "fontFamily",
+  fontfamilydefault: "fontFamily",
+  font: "fontFamily",
+  fontsize: "fontSize",
+  textsize: "fontSize",
+  typeface: "fontFamily",
+  fontweight: "fontWeight",
+  weight: "fontWeight",
+  lineheight: "lineHeight",
+  leading: "lineHeight",
+  line: "lineHeight",
+};
+
+const VIEWPORT_KEYS: Record<string, keyof TextThemeTokens> = {
+  desktop: "typographyDesktop",
+  tablet: "typographyTablet",
+  mobile: "typographyMobile",
+};
+
+const PREFIXES = new Set(["text", "typography", "type", "font", "styles"]);
+
+function normalizeSegment(segment: string): string {
+  return segment.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => {
+      const normalized = part.toLowerCase();
+      if (normalized.length <= 3 && /^[a-z]+$/.test(normalized)) {
+        return normalized.toUpperCase();
+      }
+      return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+    })
+    .join(" ");
+}
+
+function pruneTypography(overrides: StyleOverrides): StyleOverrides {
+  const next: StyleOverrides = { ...overrides };
+  (['typography', 'typographyDesktop', 'typographyTablet', 'typographyMobile'] as const).forEach((key) => {
+    const value = next[key];
+    if (!value) return;
+    const clone = { ...value } as Record<string, string | undefined>;
+    Object.keys(clone).forEach((prop) => {
+      if (clone[prop] === undefined) delete clone[prop];
+    });
+    if (Object.keys(clone).length === 0) {
+      delete next[key];
+    } else {
+      next[key] = clone as typeof value;
+    }
+  });
+  return next;
+}
+
+export function extractTextThemes(tokens: Record<string, string>): TextTheme[] {
+  const themes = new Map<string, TextTheme>();
+
+  Object.keys(tokens).forEach((originalKey) => {
+    if (!originalKey.startsWith("--")) return;
+    const trimmed = originalKey.slice(2);
+    const segments = trimmed
+      .split(/[-_]/)
+      .map((segment) => segment.trim())
+      .filter(Boolean)
+      .map((segment) => segment.toLowerCase());
+    if (segments.length < 2) return;
+
+    let viewport: keyof TextThemeTokens | undefined;
+    const lastSegment = segments[segments.length - 1];
+    if (VIEWPORT_KEYS[lastSegment]) {
+      viewport = VIEWPORT_KEYS[lastSegment];
+      segments.pop();
+    }
+
+    if (segments.length < 2) return;
+
+    const maybePropSegments = segments.slice(-2);
+    const combinedProp = normalizeSegment(maybePropSegments.join(""));
+    let propKey = PROP_KEYS[combinedProp];
+    if (!propKey) {
+      const single = normalizeSegment(segments[segments.length - 1]);
+      propKey = PROP_KEYS[single];
+      if (propKey) {
+        segments.pop();
+      }
+    } else {
+      segments.pop();
+      segments.pop();
+    }
+
+    if (!propKey) return;
+
+    while (segments.length > 0 && PREFIXES.has(segments[0])) {
+      segments.shift();
+    }
+    if (segments.length === 0) return;
+
+    const styleName = segments.join("-");
+    if (!styleName) return;
+
+    const id = styleName;
+    const label = toTitleCase(styleName);
+
+    const existing = themes.get(id) ?? { id, label, tokens: {} };
+    const targetGroup = viewport ?? "typography";
+
+    const writableGroup =
+      propKey === "fontFamily" && targetGroup !== "typography"
+        ? "typography"
+        : targetGroup;
+
+    const target = existing.tokens[writableGroup] ?? {};
+    (target as Record<string, string>)[propKey] = `--${trimmed}`;
+    existing.tokens[writableGroup] = target as never;
+    themes.set(id, existing);
+  });
+
+  return Array.from(themes.values()).sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function applyTextThemeToOverrides(
+  overrides: StyleOverrides | undefined,
+  theme: TextTheme,
+): StyleOverrides {
+  const base = overrides ? { ...overrides } : {};
+  const next: StyleOverrides = {
+    ...base,
+    typography: { ...(base.typography ?? {}) },
+    typographyDesktop: { ...(base.typographyDesktop ?? {}) },
+    typographyTablet: { ...(base.typographyTablet ?? {}) },
+    typographyMobile: { ...(base.typographyMobile ?? {}) },
+    color: base.color ? { ...base.color } : base.color,
+    effects: base.effects ? { ...base.effects } : base.effects,
+  };
+
+  (['typography', 'typographyDesktop', 'typographyTablet', 'typographyMobile'] as const).forEach((group) => {
+    const tokens = theme.tokens[group];
+    if (!tokens) return;
+    const target = next[group] ?? {};
+    Object.entries(tokens).forEach(([prop, token]) => {
+      if (!token) return;
+      (target as Record<string, string>)[prop] = token;
+    });
+    next[group] = target as never;
+  });
+
+  return pruneTypography(next);
+}
+
+export function clearTextThemeFromOverrides(overrides: StyleOverrides | undefined): StyleOverrides {
+  const base = overrides ? { ...overrides } : {};
+  const next: StyleOverrides = {
+    ...base,
+    typography: base.typography ? { ...base.typography } : undefined,
+    typographyDesktop: base.typographyDesktop ? { ...base.typographyDesktop } : undefined,
+    typographyTablet: base.typographyTablet ? { ...base.typographyTablet } : undefined,
+    typographyMobile: base.typographyMobile ? { ...base.typographyMobile } : undefined,
+    color: base.color ? { ...base.color } : base.color,
+    effects: base.effects ? { ...base.effects } : base.effects,
+  };
+
+  if (next.typography) {
+    delete next.typography.fontFamily;
+    delete next.typography.fontSize;
+    delete next.typography.fontWeight;
+    delete next.typography.lineHeight;
+  }
+  if (next.typographyDesktop) {
+    delete next.typographyDesktop.fontSize;
+    delete next.typographyDesktop.lineHeight;
+  }
+  if (next.typographyTablet) {
+    delete next.typographyTablet.fontSize;
+    delete next.typographyTablet.lineHeight;
+  }
+  if (next.typographyMobile) {
+    delete next.typographyMobile.fontSize;
+    delete next.typographyMobile.lineHeight;
+  }
+
+  return pruneTypography(next);
+}
+
+export function getAppliedTextTheme(
+  overrides: StyleOverrides | undefined,
+  themes: TextTheme[],
+): TextTheme | null {
+  if (!overrides) return null;
+  return (
+    themes.find((theme) => {
+      return (['typography', 'typographyDesktop', 'typographyTablet', 'typographyMobile'] as const).every((group) => {
+        const tokens = theme.tokens[group];
+        if (!tokens) return true;
+        const current = overrides[group];
+        if (!current) return false;
+        return Object.entries(tokens).every(([prop, token]) => (current as Record<string, string | undefined>)[prop] === token);
+      });
+    }) ?? null
+  );
+}
+
+export function toCssValue(token: string | undefined): string | undefined {
+  if (!token) return undefined;
+  return token.startsWith("--") ? `var(${token})` : token;
+}


### PR DESCRIPTION
## Summary
- add utilities for parsing and applying text theme tokens
- surface available text themes in the palette and style inspector with global apply events
- wire the sidebar to handle palette text theme events and add translations for the new control

## Testing
- pnpm --filter @acme/ui exec -- env JEST_FORCE_CJS=1 jest --runInBand --coverage=false --config ../../jest.config.cjs --runTestsByPath src/components/cms/page-builder/__tests__/textThemes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d1a4c9ce90832fb9ee8cbb9219fc4d