### PR TITLE
Refactor page builder sidebar components

### DIFF
--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/AnimationTabContent.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/AnimationTabContent.tsx
@@ -1,0 +1,21 @@
+import type { PageComponent } from "@acme/types";
+
+import InteractionsPanel from "../../panels/InteractionsPanel";
+import TimelinePanel from "../../panels/TimelinePanel";
+import LottieControls from "../../panels/LottieControls";
+import type { HandleFieldInput } from "./types";
+
+interface AnimationTabContentProps {
+  component: PageComponent;
+  handleFieldInput: HandleFieldInput;
+}
+
+const AnimationTabContent = ({ component, handleFieldInput }: AnimationTabContentProps) => (
+  <div className="space-y-3">
+    <InteractionsPanel component={component} handleInput={handleFieldInput} />
+    <TimelinePanel component={component} handleInput={handleFieldInput} />
+    <LottieControls component={component} handleInput={handleFieldInput} />
+  </div>
+);
+
+export default AnimationTabContent;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/CenterInParentActionButtons.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/CenterInParentActionButtons.tsx
@@ -1,0 +1,24 @@
+import { Tooltip } from "../../../../atoms";
+import { Button } from "../../../../atoms/shadcn";
+
+interface CenterInParentActionButtonsProps {
+  onCenterX: () => void;
+  onCenterY: () => void;
+}
+
+const CenterInParentActionButtons = ({ onCenterX, onCenterY }: CenterInParentActionButtonsProps) => (
+  <div className="flex flex-wrap gap-2">
+    <Tooltip text="Center horizontally in parent (absolute only)">
+      <Button type="button" variant="outline" aria-label="Center horizontally in parent" onClick={onCenterX}>
+        Center H in parent
+      </Button>
+    </Tooltip>
+    <Tooltip text="Center vertically in parent (absolute only)">
+      <Button type="button" variant="outline" aria-label="Center vertically in parent" onClick={onCenterY}>
+        Center V in parent
+      </Button>
+    </Tooltip>
+  </div>
+);
+
+export default CenterInParentActionButtons;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/CenterInParentButtons.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/CenterInParentButtons.tsx
@@ -1,0 +1,21 @@
+import { AlignCenterHorizontallyIcon, AlignCenterVerticallyIcon } from "@radix-ui/react-icons";
+
+import { Button } from "../../../../atoms/shadcn";
+
+interface CenterInParentButtonsProps {
+  onCenterX: () => void;
+  onCenterY: () => void;
+}
+
+const CenterInParentButtons = ({ onCenterX, onCenterY }: CenterInParentButtonsProps) => (
+  <div className="flex flex-wrap items-center gap-1">
+    <Button type="button" variant="outline" className="h-7 px-2" title="Center Horizontally in parent" onClick={onCenterX}>
+      <AlignCenterHorizontallyIcon className="h-4 w-4" />
+    </Button>
+    <Button type="button" variant="outline" className="h-7 px-2" title="Center Vertically in parent" onClick={onCenterY}>
+      <AlignCenterVerticallyIcon className="h-4 w-4" />
+    </Button>
+  </div>
+);
+
+export default CenterInParentButtons;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/CmsTabContent.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/CmsTabContent.tsx
@@ -1,0 +1,23 @@
+import type { PageComponent } from "@acme/types";
+
+import DatasetEditor from "../../DatasetEditor";
+import type { UpdateComponent } from "./types";
+
+interface CmsTabContentProps {
+  component: PageComponent;
+  onChange: UpdateComponent;
+}
+
+const CmsTabContent = ({ component, onChange }: CmsTabContentProps) => (
+  <div className="space-y-2">
+    {String((component as any).type) === "Dataset" ? (
+      <DatasetEditor component={component as any} onChange={onChange} />
+    ) : (
+      <div className="rounded border p-2 text-xs text-muted-foreground">
+        Connect to CMS: select a Dataset block to edit connections.
+      </div>
+    )}
+  </div>
+);
+
+export default CmsTabContent;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/ContentTabContent.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/ContentTabContent.tsx
@@ -1,0 +1,16 @@
+import type { PageComponent } from "@acme/types";
+
+import ContentPanel from "../../panels/ContentPanel";
+import type { HandleFieldInput, UpdateComponent } from "./types";
+
+interface ContentTabContentProps {
+  component: PageComponent;
+  handleFieldInput: HandleFieldInput;
+  onChange: UpdateComponent;
+}
+
+const ContentTabContent = ({ component, handleFieldInput, onChange }: ContentTabContentProps) => (
+  <ContentPanel component={component} onChange={onChange} handleInput={handleFieldInput} />
+);
+
+export default ContentTabContent;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/DesignTabContent.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/DesignTabContent.tsx
@@ -1,0 +1,43 @@
+import type { HistoryState, PageComponent } from "@acme/types";
+
+import LayoutPanel from "../../panels/LayoutPanel";
+import StylePanel from "../../StylePanel";
+import type { HandleFieldInput } from "./types";
+
+interface DesignTabContentProps {
+  component: PageComponent;
+  handleFieldInput: HandleFieldInput;
+  handleResizeField: (field: string, value: string) => void;
+  handleFullSizeField: (field: string) => void;
+  editorFlags: HistoryState["editor"][string] | undefined;
+  editorMap: HistoryState["editor"] | undefined;
+  onUpdateEditor: (patch: any) => void;
+  updateEditorForId: (id: string, patch: any) => void;
+}
+
+const DesignTabContent = ({
+  component,
+  handleFieldInput,
+  handleResizeField,
+  handleFullSizeField,
+  editorFlags,
+  editorMap,
+  onUpdateEditor,
+  updateEditorForId,
+}: DesignTabContentProps) => (
+  <div className="space-y-3">
+    <LayoutPanel
+      component={component}
+      handleInput={handleFieldInput}
+      handleResize={handleResizeField}
+      handleFullSize={handleFullSizeField}
+      editorFlags={editorFlags as any}
+      onUpdateEditor={onUpdateEditor}
+      editorMap={editorMap}
+      updateEditorForId={updateEditorForId}
+    />
+    <StylePanel component={component} handleInput={handleFieldInput} />
+  </div>
+);
+
+export default DesignTabContent;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/DimensionInputs.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/DimensionInputs.tsx
@@ -1,0 +1,68 @@
+import UnitInput from "../../panels/layout/UnitInput";
+import { Button } from "../../../../atoms/shadcn";
+import type { BlockDimensions, HandleResize } from "./types";
+
+interface DimensionInputsProps {
+  dims: BlockDimensions;
+  selectedComponentId: string;
+  handleResize: HandleResize;
+}
+
+const DimensionInputs = ({ dims, selectedComponentId, handleResize }: DimensionInputsProps) => (
+  <div className="grid grid-cols-2 gap-2">
+    <UnitInput
+      componentId={selectedComponentId}
+      label={<span className="text-xs">X (Left)</span>}
+      value={dims.leftVal ?? ""}
+      onChange={(v) => handleResize({ [dims.leftKey]: v })}
+      axis="w"
+      cssProp="left"
+    />
+    <UnitInput
+      componentId={selectedComponentId}
+      label={<span className="text-xs">Y (Top)</span>}
+      value={dims.topVal ?? ""}
+      onChange={(v) => handleResize({ [dims.topKey]: v })}
+      axis="h"
+      cssProp="top"
+    />
+    <UnitInput
+      componentId={selectedComponentId}
+      label={<span className="text-xs">W (Width)</span>}
+      value={dims.widthVal ?? ""}
+      onChange={(v) => handleResize({ [dims.widthKey]: v })}
+      axis="w"
+      cssProp="width"
+    />
+    <Button
+      type="button"
+      variant="outline"
+      className="h-7 px-2 text-xs"
+      aria-label="Set full width"
+      title="Set full width (100%)"
+      onClick={() => handleResize({ [dims.widthKey]: "100%" })}
+    >
+      Full W
+    </Button>
+    <UnitInput
+      componentId={selectedComponentId}
+      label={<span className="text-xs">H (Height)</span>}
+      value={dims.heightVal ?? ""}
+      onChange={(v) => handleResize({ [dims.heightKey]: v })}
+      axis="h"
+      cssProp="height"
+    />
+    <Button
+      type="button"
+      variant="outline"
+      className="h-7 px-2 text-xs"
+      aria-label="Set full height"
+      title="Set full height (100%)"
+      onClick={() => handleResize({ [dims.heightKey]: "100%" })}
+    >
+      Full H
+    </Button>
+  </div>
+);
+
+export default DimensionInputs;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/DuplicateButton.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/DuplicateButton.tsx
@@ -1,0 +1,13 @@
+import { Button } from "../../../../atoms/shadcn";
+
+interface DuplicateButtonProps {
+  onDuplicate: () => void;
+}
+
+const DuplicateButton = ({ onDuplicate }: DuplicateButtonProps) => (
+  <Button type="button" variant="outline" onClick={onDuplicate}>
+    Duplicate
+  </Button>
+);
+
+export default DuplicateButton;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/GlobalActions.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/GlobalActions.tsx
@@ -1,0 +1,49 @@
+import type { Dispatch, SetStateAction } from "react";
+
+import type { GlobalItem } from "../../libraryStore";
+import { Popover, PopoverContent, PopoverTrigger } from "../../../../atoms";
+import { Button } from "../../../../atoms/shadcn";
+import GlobalsPicker from "../GlobalsPicker";
+
+interface GlobalActionsProps {
+  globals: GlobalItem[];
+  insertOpen: boolean;
+  setInsertOpen: (open: boolean) => void;
+  insertSearch: string;
+  setInsertSearch: Dispatch<SetStateAction<string>>;
+  insertGlobal: (item: GlobalItem) => void;
+  makeGlobal: () => void;
+  editGlobally: () => void;
+}
+
+const GlobalActions = ({
+  globals,
+  insertOpen,
+  setInsertOpen,
+  insertSearch,
+  setInsertSearch,
+  insertGlobal,
+  makeGlobal,
+  editGlobally,
+}: GlobalActionsProps) => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button type="button" variant="outline" onClick={makeGlobal} aria-label="Make Global">
+      Make Global
+    </Button>
+    <Button type="button" variant="outline" onClick={editGlobally} aria-label="Edit globally">
+      Edit Globally
+    </Button>
+    <Popover open={insertOpen} onOpenChange={setInsertOpen}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" aria-label="Insert Global">
+          Insert Global
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 space-y-2">
+        <GlobalsPicker globals={globals} search={insertSearch} onSearchChange={setInsertSearch} onSelect={insertGlobal} />
+      </PopoverContent>
+    </Popover>
+  </div>
+);
+
+export default GlobalActions;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/LinkedGlobalNotice.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/LinkedGlobalNotice.tsx
@@ -1,0 +1,33 @@
+import { Button } from "../../../../atoms/shadcn";
+
+interface LinkedGlobalNoticeProps {
+  globalId?: string;
+  linkedLabel: string | null;
+  onEditGlobally: () => void;
+  onUnlink: () => void;
+}
+
+const LinkedGlobalNotice = ({ globalId, linkedLabel, onEditGlobally, onUnlink }: LinkedGlobalNoticeProps) => {
+  if (!globalId || !linkedLabel) return null;
+
+  return (
+    <div
+      className="flex items-center justify-between gap-2 rounded border bg-muted/60 px-2 py-1 text-xs"
+      title="This block is linked to a Global template"
+    >
+      <div className="truncate">
+        Linked to Global: <span className="font-medium">{linkedLabel}</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button type="button" variant="outline" className="h-7 px-2 text-xs" onClick={onEditGlobally}>
+          Edit globally
+        </Button>
+        <Button type="button" variant="ghost" className="h-7 px-2 text-xs" onClick={onUnlink} title="Unlink from Global">
+          Unlink
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default LinkedGlobalNotice;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/MultiSelectionAlignmentControls.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/MultiSelectionAlignmentControls.tsx
@@ -1,0 +1,155 @@
+import {
+  AlignLeftIcon,
+  AlignRightIcon,
+  AlignTopIcon,
+  AlignBottomIcon,
+  AlignCenterHorizontallyIcon,
+  AlignCenterVerticallyIcon,
+  ColumnSpacingIcon,
+  RowSpacingIcon,
+} from "@radix-ui/react-icons";
+
+import { Button } from "../../../../atoms/shadcn";
+import {
+  alignLeft,
+  alignRight,
+  alignTop,
+  alignBottom,
+  alignCenterX,
+  alignCenterY,
+  distributeHorizontal,
+  distributeVertical,
+} from "../../state/layout/geometry";
+import type { PageComponent } from "@acme/types";
+import type { PageBuilderDispatch, Viewport } from "./types";
+
+interface MultiSelectionAlignmentControlsProps {
+  components: PageComponent[];
+  selectedIds: string[];
+  viewport: Viewport;
+  dispatch: PageBuilderDispatch;
+}
+
+const MultiSelectionAlignmentControls = ({
+  components,
+  selectedIds,
+  viewport,
+  dispatch,
+}: MultiSelectionAlignmentControlsProps) => {
+  if (selectedIds.length <= 1) return null;
+
+  const viewportSuffix = viewport === "desktop" ? "Desktop" : viewport === "tablet" ? "Tablet" : "Mobile";
+  const leftKey = `left${viewportSuffix}`;
+  const topKey = `top${viewportSuffix}`;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Align Left"
+        onClick={() =>
+          alignLeft(components, selectedIds, viewport).forEach((p) =>
+            dispatch({ type: "resize", id: p.id, [leftKey]: p.left } as any),
+          )
+        }
+      >
+        <AlignLeftIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Align Right"
+        onClick={() =>
+          alignRight(components, selectedIds, viewport).forEach((p) =>
+            dispatch({ type: "resize", id: p.id, [leftKey]: p.left } as any),
+          )
+        }
+      >
+        <AlignRightIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Align Top"
+        onClick={() =>
+          alignTop(components, selectedIds, viewport).forEach((p) =>
+            dispatch({ type: "resize", id: p.id, [topKey]: p.top } as any),
+          )
+        }
+      >
+        <AlignTopIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Align Bottom"
+        onClick={() =>
+          alignBottom(components, selectedIds, viewport).forEach((p) =>
+            dispatch({ type: "resize", id: p.id, [topKey]: p.top } as any),
+          )
+        }
+      >
+        <AlignBottomIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Center Horizontally"
+        onClick={() =>
+          alignCenterX(components, selectedIds, viewport).forEach((p) =>
+            dispatch({ type: "resize", id: p.id, [leftKey]: p.left } as any),
+          )
+        }
+      >
+        <AlignCenterHorizontallyIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Center Vertically"
+        onClick={() =>
+          alignCenterY(components, selectedIds, viewport).forEach((p) =>
+            dispatch({ type: "resize", id: p.id, [topKey]: p.top } as any),
+          )
+        }
+      >
+        <AlignCenterVerticallyIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Distribute Horizontally"
+        onClick={() =>
+          distributeHorizontal(components, selectedIds, viewport).forEach((p) =>
+            dispatch({ type: "resize", id: p.id, [leftKey]: p.left } as any),
+          )
+        }
+      >
+        <ColumnSpacingIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Distribute Vertically"
+        onClick={() =>
+          distributeVertical(components, selectedIds, viewport).forEach((p) =>
+            dispatch({ type: "resize", id: p.id, [topKey]: p.top } as any),
+          )
+        }
+      >
+        <RowSpacingIcon className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+};
+
+export default MultiSelectionAlignmentControls;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/SaveToLibraryButton.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/SaveToLibraryButton.tsx
@@ -1,0 +1,16 @@
+import { Tooltip } from "../../../../atoms";
+import { Button } from "../../../../atoms/shadcn";
+
+interface SaveToLibraryButtonProps {
+  onSave: () => void;
+}
+
+const SaveToLibraryButton = ({ onSave }: SaveToLibraryButtonProps) => (
+  <Tooltip text="Save selected blocks as a reusable snippet">
+    <Button type="button" variant="outline" onClick={onSave}>
+      Save to My Library
+    </Button>
+  </Tooltip>
+);
+
+export default SaveToLibraryButton;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/SingleSelectionAlignmentControls.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/SingleSelectionAlignmentControls.tsx
@@ -1,0 +1,171 @@
+import { useCallback } from "react";
+import {
+  AlignLeftIcon,
+  AlignRightIcon,
+  AlignTopIcon,
+  AlignBottomIcon,
+  AlignCenterHorizontallyIcon,
+  AlignCenterVerticallyIcon,
+  ColumnSpacingIcon,
+  RowSpacingIcon,
+} from "@radix-ui/react-icons";
+
+import { Button } from "../../../../atoms/shadcn";
+import type { BlockDimensions, HandleResize, UpdateComponent } from "./types";
+
+interface SingleSelectionAlignmentControlsProps {
+  selectedIds: string[];
+  dims: BlockDimensions;
+  handleChange: UpdateComponent;
+  handleResize: HandleResize;
+  centerInParentX: () => void;
+  centerInParentY: () => void;
+}
+
+const SingleSelectionAlignmentControls = ({
+  selectedIds,
+  dims,
+  handleChange,
+  handleResize,
+  centerInParentX,
+  centerInParentY,
+}: SingleSelectionAlignmentControlsProps) => {
+  if (selectedIds.length !== 1) return null;
+  const selectedId = selectedIds[0];
+
+  const withElement = useCallback(
+    (handler: (element: HTMLElement, parent: HTMLElement) => void) => () => {
+      if (!selectedId) return;
+
+      try {
+        const el = document.querySelector(`[data-component-id="${selectedId}"]`) as HTMLElement | null;
+        const parent = (el?.offsetParent as HTMLElement | null) ?? el?.parentElement ?? null;
+        if (!el || !parent) return;
+
+        handler(el, parent);
+      } catch {
+        // no-op
+      }
+    },
+    [selectedId],
+  );
+
+  if (!selectedId) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Align to parent left"
+        onClick={withElement((el, parent) => {
+          const rect = el.getBoundingClientRect();
+          const pRect = parent.getBoundingClientRect();
+          const left = Math.round(rect.left - pRect.left);
+          handleChange({ dockX: "left" } as any);
+          handleResize({ [dims.leftKey]: `${left}px`, right: undefined });
+        })}
+      >
+        <AlignLeftIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Align to parent right"
+        onClick={withElement((el, parent) => {
+          const rect = el.getBoundingClientRect();
+          const pRect = parent.getBoundingClientRect();
+          const right = Math.round(pRect.right - rect.right);
+          handleChange({ dockX: "right" } as any);
+          handleResize({ right: `${right}px`, [dims.leftKey]: "" });
+        })}
+      >
+        <AlignRightIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Align to parent top"
+        onClick={withElement((el, parent) => {
+          const rect = el.getBoundingClientRect();
+          const pRect = parent.getBoundingClientRect();
+          const top = Math.round(rect.top - pRect.top);
+          handleChange({ dockY: "top" } as any);
+          handleResize({ [dims.topKey]: `${top}px`, bottom: "" });
+        })}
+      >
+        <AlignTopIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Align to parent bottom"
+        onClick={withElement((el, parent) => {
+          const rect = el.getBoundingClientRect();
+          const pRect = parent.getBoundingClientRect();
+          const bottom = Math.round(pRect.bottom - rect.bottom);
+          handleChange({ dockY: "bottom" } as any);
+          handleResize({ bottom: `${bottom}px`, [dims.topKey]: "" });
+        })}
+      >
+        <AlignBottomIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Center Horizontally in parent"
+        onClick={centerInParentX}
+      >
+        <AlignCenterHorizontallyIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Center Vertically in parent"
+        onClick={centerInParentY}
+      >
+        <AlignCenterVerticallyIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Stretch horizontally"
+        onClick={withElement((el, parent) => {
+          const rect = el.getBoundingClientRect();
+          const pRect = parent.getBoundingClientRect();
+          const left = Math.round(rect.left - pRect.left);
+          const right = Math.round(pRect.right - rect.right);
+          handleChange({ dockX: "left" } as any);
+          handleResize({ [dims.leftKey]: `${left}px`, right: `${right}px`, width: "" });
+        })}
+      >
+        <ColumnSpacingIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-7 px-2"
+        title="Stretch vertically"
+        onClick={withElement((el, parent) => {
+          const rect = el.getBoundingClientRect();
+          const pRect = parent.getBoundingClientRect();
+          const top = Math.round(rect.top - pRect.top);
+          const bottom = Math.round(pRect.bottom - rect.bottom);
+          handleChange({ dockY: "top" } as any);
+          handleResize({ [dims.topKey]: `${top}px`, bottom: `${bottom}px`, height: "" });
+        })}
+      >
+        <RowSpacingIcon className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+};
+
+export default SingleSelectionAlignmentControls;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/StyleClipboardActions.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/StyleClipboardActions.tsx
@@ -1,0 +1,19 @@
+import { Button } from "../../../../atoms/shadcn";
+
+interface StyleClipboardActionsProps {
+  onCopy: () => void;
+  onPaste: () => void;
+}
+
+const StyleClipboardActions = ({ onCopy, onPaste }: StyleClipboardActionsProps) => (
+  <div className="flex flex-wrap gap-2">
+    <Button type="button" variant="outline" onClick={onCopy} aria-label="Copy styles">
+      Copy Styles
+    </Button>
+    <Button type="button" variant="outline" onClick={onPaste} aria-label="Paste styles">
+      Paste Styles
+    </Button>
+  </div>
+);
+
+export default StyleClipboardActions;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/TabSwitcher.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/TabSwitcher.tsx
@@ -1,0 +1,28 @@
+interface TabSwitcherProps {
+  value: "design" | "anim" | "content" | "cms";
+  onChange: (value: "design" | "anim" | "content" | "cms") => void;
+}
+
+const tabs: ReadonlyArray<["design" | "anim" | "content" | "cms", string]> = [
+  ["design", "Design"],
+  ["anim", "Animations"],
+  ["content", "Content"],
+  ["cms", "CMS"],
+];
+
+const TabSwitcher = ({ value, onChange }: TabSwitcherProps) => (
+  <div className="mt-1 flex items-center gap-1">
+    {tabs.map(([key, label]) => (
+      <button
+        key={key}
+        type="button"
+        className={`rounded px-2 py-1 text-xs ${value === key ? "bg-muted font-medium" : "border"}`}
+        onClick={() => onChange(key)}
+      >
+        {label}
+      </button>
+    ))}
+  </div>
+);
+
+export default TabSwitcher;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/UngroupButton.tsx
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/UngroupButton.tsx
@@ -1,0 +1,21 @@
+import { Tooltip } from "../../../../atoms";
+import { Button } from "../../../../atoms/shadcn";
+
+interface UngroupButtonProps {
+  show: boolean;
+  onUngroup: () => void;
+}
+
+const UngroupButton = ({ show, onUngroup }: UngroupButtonProps) => {
+  if (!show) return null;
+
+  return (
+    <Tooltip text="Ungroup children from container">
+      <Button type="button" variant="outline" onClick={onUngroup}>
+        Ungroup
+      </Button>
+    </Tooltip>
+  );
+};
+
+export default UngroupButton;

--- a/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/types.ts
+++ b/packages/ui/src/components/cms/page-builder/components/PageSidebarSingleSelection/types.ts
@@ -1,0 +1,17 @@
+import type { PageComponent } from "@acme/types";
+import type useBlockDimensions from "../../useBlockDimensions";
+import type { Action } from "../../state";
+
+export type Viewport = "desktop" | "tablet" | "mobile";
+
+export type UpdateComponent = (patch: Partial<PageComponent>) => void;
+
+export type ResizePayload = Record<string, string | undefined>;
+
+export type HandleResize = (payload: ResizePayload) => void;
+
+export type HandleFieldInput = <K extends keyof PageComponent>(field: K, value: PageComponent[K]) => void;
+
+export type BlockDimensions = ReturnType<typeof useBlockDimensions>;
+
+export type PageBuilderDispatch = (action: Action) => void;


### PR DESCRIPTION
## Summary
- break the page builder single-selection sidebar into focused subcomponents for alignment, actions, and tab content
- simplify `PageSidebarSingleSelection` by delegating to the new modules and reusing shared sidebar types
- add sidebar utility components for tabs, global actions, and clipboard controls

## Testing
- pnpm --filter @acme/ui build

------
https://chatgpt.com/codex/tasks/task_e_68d38e7dfe44832f93f57c97b131e92e