### PR TITLE
Fix canvas drag snapping when parent size unavailable

### DIFF
--- a/packages/ui/src/components/cms/page-builder/useCanvasDrag.ts
+++ b/packages/ui/src/components/cms/page-builder/useCanvasDrag.ts
@@ -126,24 +126,32 @@ export default function useCanvasDrag({
       }
       // Compute docked offsets when docking is enabled
       const parent = containerRef.current.parentElement;
-      const useRight = dockX === "right";
-      const useBottom = dockY === "bottom";
-      // Restrict to parent bounds when a parent exists
+      const parentWidth = parent?.offsetWidth ?? 0;
+      const parentHeight = parent?.offsetHeight ?? 0;
+      const hasParentWidth = parentWidth > 0;
+      const hasParentHeight = parentHeight > 0;
+      const useRight = dockX === "right" && hasParentWidth;
+      const useBottom = dockY === "bottom" && hasParentHeight;
+      // Restrict to parent bounds when a parent exists with measurable bounds
       if (parent) {
-        const maxL = Math.max(0, parent.offsetWidth - width);
-        const maxT = Math.max(0, parent.offsetHeight - height);
-        newL = Math.min(Math.max(0, newL), maxL);
-        newT = Math.min(Math.max(0, newT), maxT);
+        if (hasParentWidth) {
+          const maxL = Math.max(0, parentWidth - width);
+          newL = Math.min(Math.max(0, newL), maxL);
+        }
+        if (hasParentHeight) {
+          const maxT = Math.max(0, parentHeight - height);
+          newT = Math.min(Math.max(0, newT), maxT);
+        }
       }
       const patch: Record<string, string> = {};
       if (useRight && parent) {
-        const right = Math.round((parent.offsetWidth - (newL + width)));
+        const right = Math.round(parentWidth - (newL + width));
         patch.right = `${right}px`;
       } else {
         patch[leftKey] = `${Math.round(newL)}px`;
       }
       if (useBottom && parent) {
-        const bottom = Math.round((parent.offsetHeight - (newT + height)));
+        const bottom = Math.round(parentHeight - (newT + height));
         patch.bottom = `${bottom}px`;
       } else {
         patch[topKey] = `${Math.round(newT)}px`;


### PR DESCRIPTION
## Summary
- guard canvas drag clamping logic when parent bounds are unavailable
- fall back to left/top positioning when parent dimensions are missing to keep drag updates stable

## Testing
- pnpm --filter @acme/ui test:quick -- --runTestsByPath __tests__/PageBuilder.drag.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68d399d2561c832fbfb351c4fdcf70e2