### PR TITLE
Fix CampaignWizard preview handler recursion

### DIFF
--- a/packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx
+++ b/packages/ui/src/components/cms/marketing/campaign/CampaignWizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "../../../atoms/shadcn";
 import { Toast } from "../../../atoms";
 import { cn } from "../../../../utils/style";
@@ -117,10 +117,13 @@ export function CampaignWizard({
     goToStep(stepIndex + 1);
   };
 
-  const handlePreview = (nextPreview: CampaignPreviewData) => {
-    setPreview(nextPreview);
-    onPreviewChange?.(nextPreview);
-  };
+  const handlePreview = useCallback(
+    (nextPreview: CampaignPreviewData) => {
+      setPreview(nextPreview);
+      onPreviewChange?.(nextPreview);
+    },
+    [onPreviewChange]
+  );
 
   const handleFinish = async () => {
     if (status === "submitting") return;


### PR DESCRIPTION
## Summary
- memoize the CampaignWizard preview handler to avoid repeated state updates
- update the React imports to include useCallback

## Testing
- pnpm --filter @acme/ui test:quick -- --testPathPattern CampaignWizard

------
https://chatgpt.com/codex/tasks/task_e_68d399f38d74832f9bc445c2c8808f42