### PR TITLE
Fix loading page builder history in tests

### DIFF
--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
@@ -57,7 +57,7 @@ export function usePageBuilderState({
         })()
       : ({ past: [], present: initial, future: [], gridCols: 12, editor: {} as Record<string, any> } as any);
 
-    if (typeof window === "undefined" || process.env.NODE_ENV === "test") {
+    if (typeof window === "undefined") {
       return parsedServer;
     }
     try {


### PR DESCRIPTION
## Summary
- remove the NODE_ENV guard so usePageBuilderState loads saved history from localStorage when window is available

## Testing
- JEST_FORCE_CJS=1 pnpm exec jest --config packages/ui/jest.config.cjs --runInBand --runTestsByPath packages/ui/src/components/cms/page-builder/__tests__/usePageBuilderState.test.ts --coverage=false --collectCoverage=false --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d39a1cb35c832fb6095ee1133a050e