### PR TITLE
Update PageSidebar test to match new layout labels

### DIFF
--- a/packages/ui/__tests__/PageSidebar.test.tsx
+++ b/packages/ui/__tests__/PageSidebar.test.tsx
@@ -21,8 +21,8 @@ describe("PageSidebar", () => {
     );
 
     // onResize
-    fireEvent.click(getByText("Layout"));
-    fireEvent.change(await findByLabelText("Width (Desktop)", { exact: false }), {
+    const widthInput = await findByLabelText(/W\s*\(Width\)/i);
+    fireEvent.change(widthInput, {
       target: { value: "200" },
     });
     expect(dispatch).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- update the PageSidebar unit test to target the new width control label instead of the removed "Layout" tab

## Testing
- pnpm --filter @acme/ui test:quick -- --testPathPattern PageSidebar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d39a110f5c832fa8075b3ca6670959