### PR TITLE
Fix PageBuilder palette and preview accessibility

### DIFF
--- a/packages/ui/src/components/atoms/Tooltip.tsx
+++ b/packages/ui/src/components/atoms/Tooltip.tsx
@@ -8,12 +8,12 @@ export interface TooltipProps {
 }
 
 export const Tooltip = ({ text, children, className }: TooltipProps) => (
-  <span
-    className={cn("group relative inline-block", className)}
-    aria-hidden="true"
-  >
+  <span className={cn("group relative inline-block", className)}>
     {children}
-    <span className="bg-fg text-bg absolute top-full left-1/2 z-10 mt-2 hidden -translate-x-1/2 rounded px-2 py-1 text-xs whitespace-nowrap group-hover:block">
+    <span
+      aria-hidden="true"
+      className="bg-fg text-bg absolute top-full left-1/2 z-10 mt-2 hidden -translate-x-1/2 rounded px-2 py-1 text-xs whitespace-nowrap group-hover:block"
+    >
       {text}
     </span>
   </span>

--- a/packages/ui/src/components/cms/page-builder/PageBuilderLeftPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/PageBuilderLeftPanel.tsx
@@ -94,6 +94,8 @@ const PageBuilderLeftPanel = ({
 }: PageBuilderLeftPanelProps) => {
   const showQuickPalette = !showPalette && !showSections;
 
+  const paletteMode = mode === "section" ? "elements" : "all";
+
   return (
     <>
       <LeftRail
@@ -142,7 +144,7 @@ const PageBuilderLeftPanel = ({
           onSetSectionBackground={onSetSectionBackground}
           selectedIsSection={selectedIsSection}
           onInsertPreset={onInsertPreset}
-          mode="elements"
+          mode={paletteMode}
         />
       )}
       {showSections && (

--- a/packages/ui/src/components/cms/page-builder/TopActionBar.tsx
+++ b/packages/ui/src/components/cms/page-builder/TopActionBar.tsx
@@ -47,7 +47,8 @@ export default function TopActionBar({ onSave, onPublish, saving = false, publis
               try { window.dispatchEvent(new CustomEvent('pb:notify', { detail: { type: 'preview', title: next ? 'Preview enabled' : 'Preview disabled' } })); } catch {}
               togglePreview();
             }}
-            aria-label="Preview"
+            aria-label={showPreview ? "Hide preview" : "Show preview"}
+            title={showPreview ? "Hide preview" : "Show preview"}
           >
             {showPreview ? "Editing" : "Preview"}
           </Button>

--- a/packages/ui/src/components/cms/page-builder/panels/layout/helpers.ts
+++ b/packages/ui/src/components/cms/page-builder/panels/layout/helpers.ts
@@ -7,8 +7,10 @@ export const isOverridden = (base: unknown, val: unknown) => {
   return a !== b;
 };
 
-export const cssError = (prop: string, value?: string) =>
-  value && !globalThis.CSS?.supports(prop, value)
-    ? `Invalid ${prop} value`
-    : undefined;
+export const cssError = (prop: string, value?: string) => {
+  if (!value) return undefined;
+  const supports = globalThis.CSS?.supports;
+  if (typeof supports !== "function") return undefined;
+  return supports.call(globalThis.CSS, prop, value) ? undefined : `Invalid ${prop} value`;
+};
 


### PR DESCRIPTION
## Summary
- allow the page builder palette to include sections when editing a page
- guard cssError against missing CSS.supports during tests
- ensure the preview toggle button and tooltip content remain accessible

## Testing
- pnpm --filter @acme/ui test:quick -- --testPathPattern PageBuilder.autoSave.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d399a31df8832fa9189b6ec433e96a