### PR TITLE
Fix PageBuilder tests for updated insertion behavior

### DIFF
--- a/packages/ui/__tests__/PageBuilder.publish.test.tsx
+++ b/packages/ui/__tests__/PageBuilder.publish.test.tsx
@@ -26,7 +26,8 @@ describe("PageBuilder publishing", () => {
 
     expect(localStorage.getItem(storageKey)).not.toBeNull();
 
-    fireEvent.click(screen.getByText("Publish"));
+    const publishButton = screen.getByText("Publish", { selector: "button" });
+    fireEvent.click(publishButton);
 
     await waitFor(() => expect(localStorage.getItem(storageKey)).toBeNull());
     expect(onPublish).toHaveBeenCalled();

--- a/packages/ui/src/components/cms/page-builder/__tests__/PageBuilder.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/PageBuilder.test.tsx
@@ -123,6 +123,7 @@ describe("PageBuilder", () => {
     expect(dispatch).toHaveBeenCalledWith({
       type: "add",
       component: { id: "uid-1", type: "Section", foo: "bar", children: [] },
+      index: 0,
     });
   });
 


### PR DESCRIPTION
## Summary
- expect PageBuilder container insertions to pass the new index argument
- target the actual Publish button in the publishing test to avoid tooltip duplicates

## Testing
- pnpm --filter @acme/ui test:quick -- --runTestsByPath packages/ui/src/components/cms/page-builder/__tests__/PageBuilder.test.tsx packages/ui/__tests__/PageBuilder.publish.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d39a825a98832f9e398e3976a3a294