### PR TITLE
fix: restore language switcher locales

### DIFF
--- a/packages/i18n/src/locales.ts
+++ b/packages/i18n/src/locales.ts
@@ -1,6 +1,6 @@
 // packages/i18n/src/locales.ts
-// Limit locales to English only for now
-export const LOCALES = ["en"] as const;
+// Supported locales for the storefront experience.
+export const LOCALES = ["en", "de", "it"] as const;
 export type Locale = (typeof LOCALES)[number];
 
 export function assertLocales(


### PR DESCRIPTION
## Summary
- restore the full LOCALES list so language switching exposes English, German, and Italian
- update the locales comment to describe the storefront language support

## Testing
- JEST_DISABLE_COVERAGE_THRESHOLD=1 pnpm --filter @acme/ui test -- --testPathPattern LanguageSwitcher.a11y.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d39a5b0228832fa1a912536e1657d3