### PR TITLE
Fix page builder state hook localStorage usage in tests

### DIFF
--- a/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
+++ b/packages/ui/src/components/cms/page-builder/hooks/usePageBuilderState.ts
@@ -57,7 +57,7 @@ export function usePageBuilderState({
         })()
       : ({ past: [], present: initial, future: [], gridCols: 12, editor: {} as Record<string, any> } as any);
 
-    if (typeof window === "undefined" || process.env.NODE_ENV === "test") {
+    if (typeof window === "undefined") {
       return parsedServer;
     }
     try {


### PR DESCRIPTION
## Summary
- allow the page builder state hook to load persisted history whenever the browser APIs are available, even during tests
- keep server rendering safe by returning the server-provided history when `window` is undefined

## Testing
- pnpm --filter @acme/ui test:quick -- --runTestsByPath packages/ui/__tests__/usePageBuilderState.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d39a5069b8832f9c6027015841e78e