### PR TITLE
Fix ProductFilter URL defaults and update fetch tests

### DIFF
--- a/packages/ui/src/components/cms/blocks/ProductFilter.tsx
+++ b/packages/ui/src/components/cms/blocks/ProductFilter.tsx
@@ -65,12 +65,18 @@ export default function ProductFilter({
       if (!sp) return;
       const sz = sp.get("size");
       const co = sp.get("color");
-      const min = Number(sp.get("min"));
-      const max = Number(sp.get("max"));
+      const minRaw = sp.get("min");
+      const maxRaw = sp.get("max");
       if (sz) setSize(sz);
       if (co) setColor(co);
-      if (Number.isFinite(min)) setMinPrice(min);
-      if (Number.isFinite(max)) setMaxPrice(max);
+      if (minRaw != null) {
+        const min = Number(minRaw);
+        if (Number.isFinite(min)) setMinPrice(min);
+      }
+      if (maxRaw != null) {
+        const max = Number(maxRaw);
+        if (Number.isFinite(max)) setMaxPrice(max);
+      }
     } catch {}
   }, []);
 

--- a/packages/ui/src/components/cms/blocks/__tests__/ProductFilter.test.tsx
+++ b/packages/ui/src/components/cms/blocks/__tests__/ProductFilter.test.tsx
@@ -2,6 +2,14 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import ProductFilter from "../ProductFilter";
 import { useProductFilters } from "../../../../hooks/useProductFilters";
 
+const pushMock = jest.fn();
+let searchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => searchParams,
+}));
+
 jest.mock("../../../../hooks/useProductFilters", () => ({
   useProductFilters: jest.fn(),
 }));
@@ -16,6 +24,8 @@ describe("ProductFilter", () => {
   ];
 
   beforeEach(() => {
+    pushMock.mockReset();
+    searchParams = new URLSearchParams();
     (useProductFilters as jest.Mock).mockReturnValue({ filteredRows: products });
   });
 

--- a/packages/ui/src/components/cms/blocks/products/__tests__/fetchCollection.test.ts
+++ b/packages/ui/src/components/cms/blocks/products/__tests__/fetchCollection.test.ts
@@ -19,7 +19,15 @@ describe("fetchCollection", () => {
 
     const result = await fetchCollection("col");
 
-    expect(global.fetch).toHaveBeenCalledWith("/api/collections/col");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/collections/col",
+      {
+        next: {
+          revalidate: 60,
+          tags: ["collections", "collection:col"],
+        },
+      }
+    );
     expect(result).toEqual(skus);
   });
 


### PR DESCRIPTION
## Summary
- mock Next.js navigation hooks in the ProductFilter test and reset their state between runs
- guard ProductFilter URL parsing so filters stay at their computed defaults when no query params are present
- update fetchCollection test expectations for the new fetch cache tags

## Testing
- pnpm --filter @acme/ui test:quick -- --runTestsByPath packages/ui/src/components/cms/blocks/products/__tests__/fetchCollection.test.ts packages/ui/src/components/cms/blocks/__tests__/ProductFilter.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d39a99a5e8832f967475c4dc582070