### PR TITLE
Align UI primitives with semantic tokens

### DIFF
--- a/packages/ui/__tests__/Input.test.tsx
+++ b/packages/ui/__tests__/Input.test.tsx
@@ -27,7 +27,7 @@ describe("Input", () => {
   it("applies error styles and accessibility attributes", () => {
     render(<Input aria-label="email" error="Required" />);
     const input = screen.getByLabelText("email");
-    expect(input).toHaveClass("border-red-500");
+    expect(input).toHaveClass("border-danger");
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(screen.getByText("Required")).toHaveTextContent("Required");
   });

--- a/packages/ui/src/components/atoms/RatingStars.tsx
+++ b/packages/ui/src/components/atoms/RatingStars.tsx
@@ -11,7 +11,7 @@ function Star({ filled, size = 16 }: { filled: boolean; size?: number }) {
     <svg
       aria-hidden="true"
       viewBox="0 0 24 24"
-      className={filled ? "fill-yellow-500" : "fill-muted"}
+      className={filled ? "fill-warning" : "fill-muted"}
       width={size}
       height={size}
     >

--- a/packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx
+++ b/packages/ui/src/components/atoms/__tests__/RatingStars.test.tsx
@@ -18,7 +18,7 @@ describe("RatingStars", () => {
       expect(star).toHaveAttribute("width", size.toString());
       expect(star).toHaveAttribute("height", size.toString());
       if (index < filled) {
-        expect(star).toHaveClass("fill-yellow-500");
+        expect(star).toHaveClass("fill-warning");
       } else {
         expect(star).toHaveClass("fill-muted");
       }
@@ -30,7 +30,7 @@ describe("RatingStars", () => {
     const size = 24;
     const { container } = render(<RatingStars rating={rating} size={size} />);
 
-    const filledStars = container.querySelectorAll("svg.fill-yellow-500");
+    const filledStars = container.querySelectorAll("svg.fill-warning");
     const mutedStars = container.querySelectorAll("svg.fill-muted");
 
     expect(filledStars).toHaveLength(Math.round(rating));

--- a/packages/ui/src/components/atoms/primitives/__tests__/input.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/input.test.tsx
@@ -11,7 +11,7 @@ describe("Input primitive", () => {
   it("renders without floating label and applies error styles", () => {
     render(<Input label="Email" error="Required" />);
     const input = screen.getByLabelText("Email");
-    expect(input).toHaveClass("border-red-500");
+    expect(input).toHaveClass("border-danger");
     expect(input).toHaveAttribute("aria-invalid", "true");
 
     // exercise focus/blur handlers

--- a/packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx
+++ b/packages/ui/src/components/atoms/primitives/__tests__/textarea.test.tsx
@@ -61,7 +61,7 @@ describe("Textarea", () => {
   it("applies error class and message", () => {
     render(<Textarea error="Required" />);
     const textarea = screen.getByRole("textbox");
-    expect(textarea).toHaveClass("border-red-500");
+    expect(textarea).toHaveClass("border-danger");
     expect(textarea).toHaveAttribute("aria-invalid", "true");
 
     const error = screen.getByText("Required");

--- a/packages/ui/src/components/atoms/primitives/input.tsx
+++ b/packages/ui/src/components/atoms/primitives/input.tsx
@@ -47,14 +47,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const baseClasses = cn(
       // base
       "flex h-12 w-full rounded-md border border-input bg-input px-3 py-3 text-sm text-foreground",
-      "placeholder:text-gray-400 dark:placeholder:text-gray-500 file:border-0 file:bg-transparent file:text-sm file:font-medium",
+      "placeholder:text-muted-foreground file:border-0 file:bg-transparent file:text-sm file:font-medium",
       // ring uses tokenized color and widths
       "focus-visible:outline-none focus-visible:ring-[var(--ring-width)] focus-visible:ring-offset-[var(--ring-offset-width)]",
       "disabled:cursor-not-allowed disabled:opacity-50",
       // floating-label tweak
       floatingLabel && "peer pt-5",
-      // error border
-      error ? "border-red-500" : undefined,
+      // error border leverages semantic color token
+      error ? "border-danger" : undefined,
       // user-supplied
       className
     );

--- a/packages/ui/src/components/atoms/primitives/textarea.tsx
+++ b/packages/ui/src/components/atoms/primitives/textarea.tsx
@@ -44,7 +44,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       "min-h-[6rem] w-full rounded-md border border-input bg-input px-3 py-2 text-sm text-foreground",
       "focus-visible:outline-none focus-visible:ring-[var(--ring-width)] focus-visible:ring-offset-[var(--ring-offset-width)] disabled:cursor-not-allowed disabled:opacity-50",
       floatingLabel && "peer pt-5",
-      hasError && "border-red-500",
+      hasError && "border-danger",
       className
     );
 


### PR DESCRIPTION
## Summary
- update the Input primitive to use the semantic danger border and muted placeholder tokens
- mirror the same danger token in Textarea and switch RatingStars to the warning fill color
- refresh Input/Textarea/RatingStars tests to assert the new styling tokens

## Testing
- JEST_FORCE_CJS=1 pnpm exec jest --runInBand --runTestsByPath --config ./jest.config.cjs __tests__/Input.test.tsx src/components/atoms/__tests__/RatingStars.test.tsx src/components/atoms/primitives/__tests__/input.test.tsx src/components/atoms/primitives/__tests__/textarea.test.tsx --no-coverage

------
https://chatgpt.com/codex/tasks/task_e_68d3fe2bb678832faf12a9815f7da795