### PR TITLE
chore: ignore storybook build in eslint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,7 @@ module.exports = {
     "**/dist/**", // compiled packages
     "packages/auth/dist/",
     "**/.next/**", // Next.js build output
+    "**/storybook-static/**", // generated Storybook bundles
     "**/index.js",
     "**/*.d.ts.map",
     "**/jest.config.*",


### PR DESCRIPTION
## Summary
- exclude generated `storybook-static` assets from ESLint to avoid linting built bundles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbea8f9ee0832f83390f4286d02893