### PR TITLE
Refactor Storybook stories to use decorators for layout wrappers

### DIFF
--- a/packages/ui/src/components/atoms/Alert.stories.tsx
+++ b/packages/ui/src/components/atoms/Alert.stories.tsx
@@ -4,28 +4,34 @@ import { Alert } from "./Alert";
 const meta: Meta<typeof Alert> = {
   title: "Atoms/Alert",
   component: Alert,
+  decorators: [
+    (Story) => (
+      <div className="space-y-3">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const Variants: StoryObj<typeof Alert> = {
   render: () => (
-    <div className="space-y-3">
+    <>
       <Alert title="Info">Default soft info message.</Alert>
       <Alert variant="success" title="Success">Saved successfully.</Alert>
       <Alert variant="warning" title="Warning">Please review the fields.</Alert>
       <Alert variant="danger" title="Danger">Something went wrong.</Alert>
-    </div>
+    </>
   ),
 };
 
 export const Solid: StoryObj<typeof Alert> = {
   render: () => (
-    <div className="space-y-3">
+    <>
       <Alert tone="solid" title="Info (solid)">Default solid info.</Alert>
       <Alert tone="solid" variant="success" title="Success (solid)">Saved.</Alert>
       <Alert tone="solid" variant="warning" title="Warning (solid)">Check inputs.</Alert>
       <Alert tone="solid" variant="danger" title="Danger (solid)">Error occurred.</Alert>
-    </div>
+    </>
   ),
 };
-

--- a/packages/ui/src/components/atoms/Chip.stories.tsx
+++ b/packages/ui/src/components/atoms/Chip.stories.tsx
@@ -4,23 +4,30 @@ import { Chip } from "./Chip";
 const meta: Meta<typeof Chip> = {
   title: "Atoms/Chip",
   component: Chip,
+  decorators: [
+    (Story) => (
+      <div className="flex flex-wrap items-center gap-2">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const BackCompatVariants: StoryObj<typeof Chip> = {
   render: () => (
-    <div className="flex flex-wrap items-center gap-2">
+    <>
       <Chip>default</Chip>
       <Chip variant="success">success</Chip>
       <Chip variant="warning">warning</Chip>
       <Chip variant="destructive">destructive</Chip>
-    </div>
+    </>
   ),
 };
 
 export const TonesAndColors: StoryObj<typeof Chip> = {
   render: () => (
-    <div className="flex flex-wrap items-center gap-2">
+    <>
       <Chip color="primary" tone="soft">primary soft</Chip>
       <Chip color="primary" tone="solid">primary solid</Chip>
       <Chip color="success" tone="soft">success soft</Chip>
@@ -29,7 +36,6 @@ export const TonesAndColors: StoryObj<typeof Chip> = {
       <Chip color="warning" tone="solid">warning solid</Chip>
       <Chip color="danger" tone="soft">danger soft</Chip>
       <Chip color="danger" tone="solid">danger solid</Chip>
-    </div>
+    </>
   ),
 };
-

--- a/packages/ui/src/components/atoms/LinkText.stories.tsx
+++ b/packages/ui/src/components/atoms/LinkText.stories.tsx
@@ -8,48 +8,74 @@ const meta: Meta<typeof LinkText> = {
 export default meta;
 
 export const Default: StoryObj<typeof LinkText> = {
+  decorators: [
+    (Story) => (
+      <div className="space-x-3">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="space-x-3">
+    <>
       <LinkText href="/">default</LinkText>
       <LinkText color="primary" href="/">primary</LinkText>
       <LinkText color="accent" href="/">accent</LinkText>
       <LinkText color="danger" href="/">danger</LinkText>
-    </div>
+    </>
   ),
 };
 
 export const SoftTone: StoryObj<typeof LinkText> = {
+  decorators: [
+    (Story) => (
+      <div className="space-x-3">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="space-x-3">
+    <>
       <LinkText tone="soft" href="/">default soft</LinkText>
       <LinkText tone="soft" color="primary" href="/">primary soft</LinkText>
       <LinkText tone="soft" color="accent" href="/">accent soft</LinkText>
       <LinkText tone="soft" color="danger" href="/">danger soft</LinkText>
-    </div>
+    </>
   ),
 };
 
 export const InsidePanel: StoryObj<typeof LinkText> = {
+  decorators: [
+    (Story) => (
+      <div className="bg-panel border border-border-2 p-4">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="bg-panel border border-border-2 p-4">
-      <p className="text-sm text-muted-foreground">
-        This is a panel. <LinkText color="primary">Primary link</LinkText> and
-        <span> </span>
-        <LinkText tone="soft" color="accent">accent soft link</LinkText> render with appropriate contrast.
-      </p>
-    </div>
+    <p className="text-sm text-muted-foreground">
+      This is a panel. <LinkText color="primary">Primary link</LinkText> and
+      <span> </span>
+      <LinkText tone="soft" color="accent">accent soft link</LinkText> render with appropriate contrast.
+    </p>
   ),
 };
 
 export const AsChild: StoryObj<typeof LinkText> = {
+  decorators: [
+    (Story) => (
+      <div className="space-x-3">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="space-x-3">
+    <>
       <LinkText asChild color="primary">
         <a href="/">asChild anchor</a>
       </LinkText>
       <LinkText asChild tone="soft" color="accent">
         <button type="button">asChild button</button>
       </LinkText>
-    </div>
+    </>
   ),
 };

--- a/packages/ui/src/components/atoms/Popover.stories.tsx
+++ b/packages/ui/src/components/atoms/Popover.stories.tsx
@@ -5,21 +5,25 @@ import { Button } from "./primitives/button";
 const meta: Meta<typeof Popover> = {
   title: "Atoms/Popover",
   component: Popover,
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const PanelSurface: StoryObj<typeof Popover> = {
   render: () => (
-    <div className="p-8">
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button>Open popover</Button>
-        </PopoverTrigger>
-        <PopoverContent>
-          <div className="text-sm">Token-driven panel surface</div>
-        </PopoverContent>
-      </Popover>
-    </div>
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button>Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="text-sm">Token-driven panel surface</div>
+      </PopoverContent>
+    </Popover>
   ),
 };
-

--- a/packages/ui/src/components/atoms/ProductBadge.stories.tsx
+++ b/packages/ui/src/components/atoms/ProductBadge.stories.tsx
@@ -4,22 +4,29 @@ import { ProductBadge } from "./ProductBadge";
 const meta: Meta<typeof ProductBadge> = {
   title: "Atoms/ProductBadge",
   component: ProductBadge,
+  decorators: [
+    (Story) => (
+      <div className="flex flex-wrap items-center gap-2">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const BackCompatVariants: StoryObj<typeof ProductBadge> = {
   render: () => (
-    <div className="flex flex-wrap items-center gap-2">
+    <>
       <ProductBadge label="default" />
       <ProductBadge variant="sale" label="sale" />
       <ProductBadge variant="new" label="new" />
-    </div>
+    </>
   ),
 };
 
 export const TonesAndColors: StoryObj<typeof ProductBadge> = {
   render: () => (
-    <div className="flex flex-wrap items-center gap-2">
+    <>
       <ProductBadge color="success" tone="soft" label="success soft" />
       <ProductBadge color="success" tone="solid" label="success solid" />
       <ProductBadge color="danger" tone="soft" label="danger soft" />
@@ -28,7 +35,6 @@ export const TonesAndColors: StoryObj<typeof ProductBadge> = {
       <ProductBadge color="primary" tone="solid" label="primary solid" />
       <ProductBadge color="accent" tone="soft" label="accent soft" />
       <ProductBadge color="accent" tone="solid" label="accent solid" />
-    </div>
+    </>
   ),
 };
-

--- a/packages/ui/src/components/atoms/StockStatus.stories.tsx
+++ b/packages/ui/src/components/atoms/StockStatus.stories.tsx
@@ -8,11 +8,17 @@ const meta: Meta<typeof StockStatus> = {
 export default meta;
 
 export const Variants: StoryObj<typeof StockStatus> = {
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-4">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="flex items-center gap-4">
+    <>
       <StockStatus inStock />
       <StockStatus inStock={false} />
-    </div>
+    </>
   ),
 };
-

--- a/packages/ui/src/components/atoms/Tag.stories.tsx
+++ b/packages/ui/src/components/atoms/Tag.stories.tsx
@@ -8,33 +8,45 @@ const meta: Meta<typeof Tag> = {
 export default meta;
 
 export const Variants: StoryObj<typeof Tag> = {
+  decorators: [
+    (Story) => (
+      <div className="flex gap-2">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="flex gap-2">
+    <>
       <Tag>Default</Tag>
       <Tag variant="success">Success</Tag>
       <Tag variant="warning">Warning</Tag>
       <Tag variant="destructive">Destructive</Tag>
-    </div>
+    </>
   ),
 };
 
 export const TonesAndColors: StoryObj<typeof Tag> = {
-  render: () => (
-    <div className="flex flex-col gap-3">
+  decorators: [
+    (Story) => (
       <div className="flex flex-wrap items-center gap-2">
-        <Tag color="primary" tone="soft">primary soft</Tag>
-        <Tag color="primary" tone="solid">primary solid</Tag>
-        <Tag color="accent" tone="soft">accent soft</Tag>
-        <Tag color="accent" tone="solid">accent solid</Tag>
-        <Tag color="success" tone="soft">success soft</Tag>
-        <Tag color="success" tone="solid">success solid</Tag>
-        <Tag color="info" tone="soft">info soft</Tag>
-        <Tag color="info" tone="solid">info solid</Tag>
-        <Tag color="warning" tone="soft">warning soft</Tag>
-        <Tag color="warning" tone="solid">warning solid</Tag>
-        <Tag color="danger" tone="soft">danger soft</Tag>
-        <Tag color="danger" tone="solid">danger solid</Tag>
+        <Story />
       </div>
-    </div>
+    ),
+  ],
+  render: () => (
+    <>
+      <Tag color="primary" tone="soft">primary soft</Tag>
+      <Tag color="primary" tone="solid">primary solid</Tag>
+      <Tag color="accent" tone="soft">accent soft</Tag>
+      <Tag color="accent" tone="solid">accent solid</Tag>
+      <Tag color="success" tone="soft">success soft</Tag>
+      <Tag color="success" tone="solid">success solid</Tag>
+      <Tag color="info" tone="soft">info soft</Tag>
+      <Tag color="info" tone="solid">info solid</Tag>
+      <Tag color="warning" tone="soft">warning soft</Tag>
+      <Tag color="warning" tone="solid">warning solid</Tag>
+      <Tag color="danger" tone="soft">danger soft</Tag>
+      <Tag color="danger" tone="solid">danger solid</Tag>
+    </>
   ),
 };

--- a/packages/ui/src/components/atoms/Toast.stories.tsx
+++ b/packages/ui/src/components/atoms/Toast.stories.tsx
@@ -5,30 +5,36 @@ import * as React from "react";
 const meta: Meta<typeof Toast> = {
   title: "Atoms/Toast",
   component: Toast,
+  decorators: [
+    (Story) => (
+      <div className="space-y-3">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const SoftVariants: StoryObj<typeof Toast> = {
   render: () => (
-    <div className="space-y-3">
+    <>
       <Toast open message="Default soft toast" />
       <Toast open variant="info" message="Info soft toast" />
       <Toast open variant="success" message="Success soft toast" />
       <Toast open variant="warning" message="Warning soft toast" />
       <Toast open variant="danger" message="Danger soft toast" />
-    </div>
+    </>
   ),
 };
 
 export const SolidVariants: StoryObj<typeof Toast> = {
   render: () => (
-    <div className="space-y-3">
+    <>
       <Toast open tone="solid" message="Default solid toast" />
       <Toast open tone="solid" variant="info" message="Info solid toast" />
       <Toast open tone="solid" variant="success" message="Success solid toast" />
       <Toast open tone="solid" variant="warning" message="Warning solid toast" />
       <Toast open tone="solid" variant="danger" message="Danger solid toast" />
-    </div>
+    </>
   ),
 };
-

--- a/packages/ui/src/components/atoms/Tooltip.stories.tsx
+++ b/packages/ui/src/components/atoms/Tooltip.stories.tsx
@@ -14,20 +14,25 @@ const meta: Meta<TooltipStoryProps> = {
 export default meta;
 
 export const Default: StoryObj<TooltipStoryProps> = {
+  decorators: [
+    (Story) => (
+      <div className="flex justify-center">
+        <Story />
+      </div>
+    ),
+  ],
   render: (args) => (
-    <div className="flex justify-center">
-      <Tooltip
-        text={args.text}
-        className={
-          args.position === "bottom"
-            ? "flex flex-col-reverse items-center"
-            : undefined
-        }
-      >
-        <button className="border p-2 min-h-10 min-w-10">
-          <Icon name="heart" width={16} height={16} />
-        </button>
-      </Tooltip>
-    </div>
+    <Tooltip
+      text={args.text}
+      className={
+        args.position === "bottom"
+          ? "flex flex-col-reverse items-center"
+          : undefined
+      }
+    >
+      <button className="border p-2 min-h-10 min-w-10">
+        <Icon name="heart" width={16} height={16} />
+      </button>
+    </Tooltip>
   ),
 };

--- a/packages/ui/src/components/atoms/primitives/Button.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Button.stories.tsx
@@ -8,19 +8,33 @@ const meta: Meta<typeof Button> = {
 export default meta;
 
 export const LegacyVariants: StoryObj<typeof Button> = {
+  decorators: [
+    (Story) => (
+      <div className="flex flex-wrap items-center gap-2">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="flex flex-wrap items-center gap-2">
+    <>
       <Button variant="default">default</Button>
       <Button variant="outline">outline</Button>
       <Button variant="ghost">ghost</Button>
       <Button variant="destructive">destructive</Button>
-    </div>
+    </>
   ),
 };
 
 export const TonesAndColors: StoryObj<typeof Button> = {
+  decorators: [
+    (Story) => (
+      <div className="flex flex-col gap-3">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="flex flex-col gap-3">
+    <>
       <div className="flex flex-wrap items-center gap-2">
         <Button color="primary" tone="solid">primary solid</Button>
         <Button color="primary" tone="soft">primary soft</Button>
@@ -43,13 +57,20 @@ export const TonesAndColors: StoryObj<typeof Button> = {
         <Button color="danger" tone="solid">danger solid</Button>
         <Button color="danger" tone="soft">danger soft</Button>
       </div>
-    </div>
+    </>
   ),
 };
 
 export const WithIconsAndLoading: StoryObj<typeof Button> = {
+  decorators: [
+    (Story) => (
+      <div className="flex flex-wrap items-center gap-2">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="flex flex-wrap items-center gap-2">
+    <>
       <Button leadingIcon={<span aria-hidden>★</span>}>
         Leading icon
       </Button>
@@ -64,6 +85,6 @@ export const WithIconsAndLoading: StoryObj<typeof Button> = {
       </Button>
       <Button disabled>Disabled</Button>
       <Button aria-disabled color="accent">Aria-disabled</Button>
-    </div>
+    </>
   ),
 };

--- a/packages/ui/src/components/atoms/primitives/Card.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Card.stories.tsx
@@ -4,12 +4,19 @@ import { Card, CardContent } from "./card";
 const meta: Meta<typeof Card> = {
   title: "Primitives/Card",
   component: Card,
+  decorators: [
+    (Story) => (
+      <div className="grid gap-4 p-8 @md:grid-cols-2">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const Surfaces: StoryObj<typeof Card> = {
   render: () => (
-    <div className="grid gap-4 p-8 @md:grid-cols-2">
+    <>
       <Card>
         <CardContent>
           <div className="text-sm">Default panel surface</div>
@@ -20,7 +27,6 @@ export const Surfaces: StoryObj<typeof Card> = {
           <div className="text-sm">Elevated surface (surface-3)</div>
         </CardContent>
       </Card>
-    </div>
+    </>
   ),
 };
-

--- a/packages/ui/src/components/atoms/primitives/Input.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Input.stories.tsx
@@ -4,17 +4,23 @@ import { Input } from "./input";
 const meta: Meta<typeof Input> = {
   title: "Primitives/Input",
   component: Input,
+  decorators: [
+    (Story) => (
+      <div className="space-y-3">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const States: StoryObj<typeof Input> = {
   render: () => (
-    <div className="space-y-3">
+    <>
       <Input placeholder="Placeholder" />
       <Input placeholder="With error" error="Required" />
       <Input placeholder="Disabled" disabled />
       <Input placeholder="Floating label" label="Email" floatingLabel />
-    </div>
+    </>
   ),
 };
-

--- a/packages/ui/src/components/atoms/primitives/Select.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Select.stories.tsx
@@ -13,28 +13,32 @@ import {
 const meta: Meta<typeof Select> = {
   title: "Primitives/Select",
   component: Select,
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const PanelSurface: StoryObj<typeof Select> = {
   render: () => (
-    <div className="p-8">
-      <Select>
-        <SelectTrigger className="w-56">
-          <SelectValue placeholder="Choose a fruit" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            <SelectLabel>Fruits</SelectLabel>
-            <SelectItem value="apple">Apple</SelectItem>
-            <SelectItem value="banana">Banana</SelectItem>
-            <SelectItem value="grapes">Grapes</SelectItem>
-            <SelectSeparator />
-            <SelectItem value="kiwi">Kiwi</SelectItem>
-          </SelectGroup>
-        </SelectContent>
-      </Select>
-    </div>
+    <Select>
+      <SelectTrigger className="w-56">
+        <SelectValue placeholder="Choose a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Fruits</SelectLabel>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="grapes">Grapes</SelectItem>
+          <SelectSeparator />
+          <SelectItem value="kiwi">Kiwi</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
   ),
 };
-

--- a/packages/ui/src/components/atoms/primitives/Table.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Table.stories.tsx
@@ -5,37 +5,42 @@ import { Stack } from "./Stack";
 const meta: Meta<typeof Table> = {
   title: "Primitives/Table",
   component: Table,
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const HoverVsSelected: StoryObj<typeof Table> = {
   render: () => (
-    <div className="p-8">
-      <Stack gap={3}>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Product</TableHead>
-              <TableHead>Price</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            <TableRow>
-              <TableCell>Widget A</TableCell>
-              <TableCell>$10</TableCell>
-            </TableRow>
-            <TableRow data-state="selected">
-              <TableCell>Widget B (selected)</TableCell>
-              <TableCell>$20</TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell>Widget C</TableCell>
-              <TableCell>$30</TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-        <p className="text-sm text-muted-foreground">Hover rows to see surface-2; selected row uses surface-3.</p>
-      </Stack>
-    </div>
+    <Stack gap={3}>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Product</TableHead>
+            <TableHead>Price</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Widget A</TableCell>
+            <TableCell>$10</TableCell>
+          </TableRow>
+          <TableRow data-state="selected">
+            <TableCell>Widget B (selected)</TableCell>
+            <TableCell>$20</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Widget C</TableCell>
+            <TableCell>$30</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+      <p className="text-sm text-muted-foreground">Hover rows to see surface-2; selected row uses surface-3.</p>
+    </Stack>
   ),
 };

--- a/packages/ui/src/components/atoms/primitives/Textarea.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Textarea.stories.tsx
@@ -4,17 +4,23 @@ import { Textarea } from "./textarea";
 const meta: Meta<typeof Textarea> = {
   title: "Primitives/Textarea",
   component: Textarea,
+  decorators: [
+    (Story) => (
+      <div className="space-y-3">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const States: StoryObj<typeof Textarea> = {
   render: () => (
-    <div className="space-y-3">
+    <>
       <Textarea placeholder="Enter details" />
       <Textarea placeholder="With error" error="Explain more" />
       <Textarea placeholder="Disabled" disabled />
       <Textarea placeholder="Floating label" label="Notes" floatingLabel />
-    </div>
+    </>
   ),
 };
-

--- a/packages/ui/src/components/atoms/primitives/drawer.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/drawer.stories.tsx
@@ -5,45 +5,48 @@ import { OverlayScrim } from "../index";
 const meta: Meta<typeof Drawer> = {
   title: "Primitives/Drawer",
   component: Drawer,
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const Right: StoryObj<typeof Drawer> = {
   render: () => (
-    <div className="p-8">
-      <Drawer>
-        <DrawerTrigger asChild>
-          {/* i18n-exempt: story demo control label */}
-          <button className="rounded border px-4 min-h-10 min-w-10">Open right drawer</button>
-        </DrawerTrigger>
-        <DrawerPortal>
-          <OverlayScrim />
-          <DrawerContent side="right" width="w-80" className="p-6">
-            {/* i18n-exempt: story demo content */}
-            <div className="text-sm">Panel surface drawer (right)</div>
-          </DrawerContent>
-        </DrawerPortal>
-      </Drawer>
-    </div>
+    <Drawer>
+      <DrawerTrigger asChild>
+        {/* i18n-exempt: story demo control label */}
+        <button className="rounded border px-4 min-h-10 min-w-10">Open right drawer</button>
+      </DrawerTrigger>
+      <DrawerPortal>
+        <OverlayScrim />
+        <DrawerContent side="right" width="w-80" className="p-6">
+          {/* i18n-exempt: story demo content */}
+          <div className="text-sm">Panel surface drawer (right)</div>
+        </DrawerContent>
+      </DrawerPortal>
+    </Drawer>
   ),
 };
 
 export const Left: StoryObj<typeof Drawer> = {
   render: () => (
-    <div className="p-8">
-      <Drawer>
-        <DrawerTrigger asChild>
-          {/* i18n-exempt: story demo control label */}
-          <button className="rounded border px-4 min-h-10 min-w-10">Open left drawer</button>
-        </DrawerTrigger>
-        <DrawerPortal>
-          <OverlayScrim />
-          <DrawerContent side="left" width="w-64" className="p-6">
-            {/* i18n-exempt: story demo content */}
-            <div className="text-sm">Panel surface drawer (left)</div>
-          </DrawerContent>
-        </DrawerPortal>
-      </Drawer>
-    </div>
+    <Drawer>
+      <DrawerTrigger asChild>
+        {/* i18n-exempt: story demo control label */}
+        <button className="rounded border px-4 min-h-10 min-w-10">Open left drawer</button>
+      </DrawerTrigger>
+      <DrawerPortal>
+        <OverlayScrim />
+        <DrawerContent side="left" width="w-64" className="p-6">
+          {/* i18n-exempt: story demo content */}
+          <div className="text-sm">Panel surface drawer (left)</div>
+        </DrawerContent>
+      </DrawerPortal>
+    </Drawer>
   ),
 };

--- a/packages/ui/src/components/atoms/primitives/dropdown-menu.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/dropdown-menu.stories.tsx
@@ -12,49 +12,53 @@ import { Button } from "./button";
 const meta: Meta<typeof DropdownMenu> = {
   title: "Primitives/DropdownMenu",
   component: DropdownMenu,
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const PanelSurface: StoryObj<typeof DropdownMenu> = {
   render: () => (
-    <div className="p-8">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button>Open menu</Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-56">
-          <DropdownMenuLabel>Quick actions</DropdownMenuLabel>
-          <DropdownMenuItem>Duplicate</DropdownMenuItem>
-          <DropdownMenuItem>Archive</DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem>Delete</DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>Open menu</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuLabel>Quick actions</DropdownMenuLabel>
+        <DropdownMenuItem>Duplicate</DropdownMenuItem>
+        <DropdownMenuItem>Archive</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Delete</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   ),
 };
 
 export const Submenu: StoryObj<typeof DropdownMenu> = {
   render: () => (
-    <div className="p-8">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button>Open menu with sub</Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-56">
-          <DropdownMenuLabel>Quick actions</DropdownMenuLabel>
-          <DropdownMenuItem>Duplicate</DropdownMenuItem>
-          <DropdownMenu.Sub>
-            <DropdownMenu.SubTrigger>Move to…</DropdownMenu.SubTrigger>
-            <DropdownMenu.SubContent className="w-40">
-              <DropdownMenuItem>Inbox</DropdownMenuItem>
-              <DropdownMenuItem>Archive</DropdownMenuItem>
-            </DropdownMenu.SubContent>
-          </DropdownMenu.Sub>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem>Delete</DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>Open menu with sub</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuLabel>Quick actions</DropdownMenuLabel>
+        <DropdownMenuItem>Duplicate</DropdownMenuItem>
+        <DropdownMenuItem>Archive</DropdownMenuItem>
+        <DropdownMenu.Sub>
+          <DropdownMenu.SubTrigger>Move to…</DropdownMenu.SubTrigger>
+          <DropdownMenu.SubContent className="w-40">
+            <DropdownMenuItem>Inbox</DropdownMenuItem>
+            <DropdownMenuItem>Archive</DropdownMenuItem>
+          </DropdownMenu.SubContent>
+        </DropdownMenu.Sub>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Delete</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   ),
 };

--- a/packages/ui/src/components/organisms/FilterSidebar.stories.tsx
+++ b/packages/ui/src/components/organisms/FilterSidebar.stories.tsx
@@ -5,14 +5,16 @@ import { FilterSidebar } from "./FilterSidebar.client";
 const meta: Meta<typeof FilterSidebar> = {
   title: "Organisms/FilterSidebar",
   component: FilterSidebar,
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const Default: StoryObj<typeof FilterSidebar> = {
-  render: () => (
-    <div className="p-8">
-      <FilterSidebar onChange={() => {}} />
-    </div>
-  ),
+  render: () => <FilterSidebar onChange={() => {}} />,
 };
-

--- a/packages/ui/src/components/organisms/OrderSummary.stories.tsx
+++ b/packages/ui/src/components/organisms/OrderSummary.stories.tsx
@@ -26,8 +26,15 @@ export default meta;
  *  Stories
  * ------------------------------------------------------------------ */
 export const Default: StoryObj<typeof OrderSummary> = {
+  decorators: [
+    (Story) => (
+      <div className="space-y-2">
+        <Story />
+      </div>
+    ),
+  ],
   render: () => (
-    <div className="space-y-2">
+    <>
       {/* OrderSummary reads cart data via the CartContext hook.
           In Storybook the context is mocked elsewhere (see preview.ts)
           so the component requires no props here. */}
@@ -59,7 +66,7 @@ export const Default: StoryObj<typeof OrderSummary> = {
           </tr>
         </tbody>
       </table>
-    </div>
+    </>
   ),
 };
 // i18n-exempt -- Storybook demo copy

--- a/packages/ui/src/components/organisms/ProductCard.stories.tsx
+++ b/packages/ui/src/components/organisms/ProductCard.stories.tsx
@@ -34,25 +34,39 @@ export default meta;
 export const Default: StoryObj<typeof ProductCard> = {};
 
 export const WithBadge: StoryObj<typeof ProductCard> = {
+  decorators: [
+    (Story) => (
+      <div className="relative">
+        <Story />
+      </div>
+    ),
+  ],
   render: (args) => (
-    <div className="relative">
+    <>
       <ProductCard {...args} />
       <ProductBadge
         label="Sale"
         variant="sale"
         className="absolute top-2 start-2"
       />
-    </div>
+    </>
   ),
 };
 
 export const OutOfStock: StoryObj<typeof ProductCard> = {
+  decorators: [
+    (Story) => (
+      <div className="relative">
+        <Story />
+      </div>
+    ),
+  ],
   render: (args) => (
-    <div className="relative">
+    <>
       <ProductCard {...args} />
       <div className="absolute inset-0 bg-fg/60 font-semibold text-bg">
         <Cover minH="[60vh]">Out of stock</Cover>
       </div>
-    </div>
+    </>
   ),
 };

--- a/packages/ui/src/components/organisms/WishlistDrawer.stories.tsx
+++ b/packages/ui/src/components/organisms/WishlistDrawer.stories.tsx
@@ -12,13 +12,21 @@ const items: SKU[] = [
 const meta: Meta<typeof WishlistDrawer> = {
   title: "Organisms/WishlistDrawer",
   component: WishlistDrawer,
+  decorators: [
+    (Story) => (
+      <div className="p-8">
+        <Story />
+      </div>
+    ),
+  ],
 };
 export default meta;
 
 export const Default: StoryObj<typeof WishlistDrawer> = {
   render: () => (
-    <div className="p-8">
-      <WishlistDrawer trigger={<button className="rounded border px-3 min-h-10 min-w-10">Open wishlist</button>} items={items} />
-    </div>
+    <WishlistDrawer
+      trigger={<button className="rounded border px-3 min-h-10 min-w-10">Open wishlist</button>}
+      items={items}
+    />
   ),
 };


### PR DESCRIPTION
## Summary
- wrap Storybook harness markup in decorators instead of inline renders across primitive and atom stories
- apply the same decorator pattern to organism stories that previously included layout containers in their render functions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbebe2050c832fa4fd12a4d9b0de1e