### PR TITLE
Include configurator Vite config in TypeScript project

### DIFF
--- a/packages/configurator/tsconfig.json
+++ b/packages/configurator/tsconfig.json
@@ -16,7 +16,7 @@
       "@acme/config/*": ["../config/src/*", "../config/dist/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "vite.config.ts"],
   "exclude": [
     "dist",
     "__tests__",


### PR DESCRIPTION
## Summary
- include the configurator Vite config in the package tsconfig so the TypeScript project service can resolve it

## Testing
- pnpm --filter @acme/configurator lint *(fails: missing @acme/eslint-plugin-ds in node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dbed750124832fb73aeb5381d9ae33