### PR TITLE
fix(types): replace nodemailer triple-slash reference

### DIFF
--- a/packages/types/src/global.d.ts
+++ b/packages/types/src/global.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="./nodemailer.d.ts" />
+import "./nodemailer";
 
 export {};
 import type * as React from "react";


### PR DESCRIPTION
## Summary
- replace the triple-slash nodemailer reference in the global types entrypoint with an import statement to satisfy linting rules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbedf1055c832fa119263ce0fc68be