### PR TITLE
chore: disable ds/no-raw-color in platform-core validation tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -188,6 +188,14 @@ export default [
     },
   },
 
+  /* ▸ Allow raw colors in platform-core validation tests */
+  {
+    files: ["packages/platform-core/src/validation/__tests__/**/*.{ts,tsx,js,jsx}"],
+    rules: {
+      "ds/no-raw-color": "off",
+    },
+  },
+
   /* ▸ CMS-only: disallow raw Tailwind palette and arbitrary colors */
   {
     files: ["apps/cms/**/*.{ts,tsx,js,jsx,mdx}"],


### PR DESCRIPTION
## Summary
- disable the ds/no-raw-color rule within platform-core validation test files so fixture colors no longer fail linting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbee4006ec832fa281aa0126cbacd3