### PR TITLE
chore(platform-core): remove unused createRequire import

### DIFF
--- a/packages/platform-core/src/plugins/resolvers.ts
+++ b/packages/platform-core/src/plugins/resolvers.ts
@@ -1,7 +1,6 @@
 import { readFile, stat } from "fs/promises";
 import path from "path";
 import { pathToFileURL } from "url";
-import { createRequire } from "module";
 import { logger } from "../utils";
 
 function unique<T>(arr: T[]): T[] {


### PR DESCRIPTION
## Summary
- remove the unused createRequire import from the platform-core resolvers implementation to satisfy linting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbee481c54832f83857b7fa70e9e3f