### PR TITLE
Fix try-on provider lint issues

### DIFF
--- a/packages/i18n/src/de.json
+++ b/packages/i18n/src/de.json
@@ -1945,6 +1945,18 @@
   "tryon.readout.scale": "Skalierung",
   "tryon.readout.rot": "Rot.",
   "tryon.readout.pos": "Pos.",
-  "tryon.reset": "Zurücksetzen"
-  ,"tryon.autoPlace": "Automatisch platzieren"
+  "tryon.reset": "Zurücksetzen",
+  "tryon.autoPlace": "Automatisch platzieren",
+  "tryon.circuitBreaker.timeout": "Timeout.",
+  "tryon.circuitBreaker.open": "Circuit open.",
+  "tryon.circuitBreaker.halfOpen": "Circuit half-open.",
+  "tryon.providers.cloudflare.originNotAllowed": "Origin not allowed.",
+  "tryon.providers.cloudflare.fetchFailed": "Failed to fetch image ({status}).",
+  "tryon.providers.cloudflare.accountIdMissing": "CLOUDFLARE_ACCOUNT_ID missing.",
+  "tryon.providers.cloudflare.apiTokenMissing": "CLOUDFLARE_API_TOKEN missing.",
+  "tryon.providers.cloudflare.upstreamError": "Upstream {status}.",
+  "tryon.providers.cloudflare.noImageInJson": "No image in JSON.",
+  "tryon.providers.garment.heavyApiUrlMissing": "TRYON_HEAVY_API_URL not set.",
+  "tryon.providers.garment.upstreamError": "Upstream {status}.",
+  "tryon.providers.garment.unexpectedResponse": "Unexpected upstream response."
 }

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -2361,7 +2361,19 @@
   "tryon.readout.scale": "Scale",
   "tryon.readout.rot": "Rot",
   "tryon.readout.pos": "Pos",
-  "tryon.reset": "Reset"
-  ,"tryon.autoPlace": "Auto place",
+  "tryon.reset": "Reset",
+  "tryon.autoPlace": "Auto place",
+  "tryon.circuitBreaker.timeout": "Timeout.",
+  "tryon.circuitBreaker.open": "Circuit open.",
+  "tryon.circuitBreaker.halfOpen": "Circuit half-open.",
+  "tryon.providers.cloudflare.originNotAllowed": "Origin not allowed.",
+  "tryon.providers.cloudflare.fetchFailed": "Failed to fetch image ({status}).",
+  "tryon.providers.cloudflare.accountIdMissing": "CLOUDFLARE_ACCOUNT_ID missing.",
+  "tryon.providers.cloudflare.apiTokenMissing": "CLOUDFLARE_API_TOKEN missing.",
+  "tryon.providers.cloudflare.upstreamError": "Upstream {status}.",
+  "tryon.providers.cloudflare.noImageInJson": "No image in JSON.",
+  "tryon.providers.garment.heavyApiUrlMissing": "TRYON_HEAVY_API_URL not set.",
+  "tryon.providers.garment.upstreamError": "Upstream {status}.",
+  "tryon.providers.garment.unexpectedResponse": "Unexpected upstream response.",
   "socialProof.recentPurchase": "{customer} bought {product} {minutes} min ago"
 }

--- a/packages/i18n/src/it.json
+++ b/packages/i18n/src/it.json
@@ -1942,6 +1942,18 @@
   "tryon.readout.scale": "Scala",
   "tryon.readout.rot": "Rot.",
   "tryon.readout.pos": "Pos.",
-  "tryon.reset": "Reimposta"
-  ,"tryon.autoPlace": "Posizionamento automatico"
+  "tryon.reset": "Reimposta",
+  "tryon.autoPlace": "Posizionamento automatico",
+  "tryon.circuitBreaker.timeout": "Timeout.",
+  "tryon.circuitBreaker.open": "Circuit open.",
+  "tryon.circuitBreaker.halfOpen": "Circuit half-open.",
+  "tryon.providers.cloudflare.originNotAllowed": "Origin not allowed.",
+  "tryon.providers.cloudflare.fetchFailed": "Failed to fetch image ({status}).",
+  "tryon.providers.cloudflare.accountIdMissing": "CLOUDFLARE_ACCOUNT_ID missing.",
+  "tryon.providers.cloudflare.apiTokenMissing": "CLOUDFLARE_API_TOKEN missing.",
+  "tryon.providers.cloudflare.upstreamError": "Upstream {status}.",
+  "tryon.providers.cloudflare.noImageInJson": "No image in JSON.",
+  "tryon.providers.garment.heavyApiUrlMissing": "TRYON_HEAVY_API_URL not set.",
+  "tryon.providers.garment.upstreamError": "Upstream {status}.",
+  "tryon.providers.garment.unexpectedResponse": "Unexpected upstream response."
 }

--- a/packages/lib/src/tryon/i18n.ts
+++ b/packages/lib/src/tryon/i18n.ts
@@ -1,0 +1,19 @@
+import en from "@acme/i18n/en.json";
+
+type Messages = typeof en;
+type MessageKey = keyof Messages;
+type TemplateVars = Record<string, string | number | boolean | undefined>;
+
+const messages: Messages = en;
+
+export function t(key: MessageKey, vars?: TemplateVars): string {
+  const template = messages[key] ?? (key as string);
+  if (!vars) return template;
+  return template.replace(/\{(.*?)\}/g, (match, name) => {
+    if (Object.prototype.hasOwnProperty.call(vars, name)) {
+      const value = vars[name];
+      return value === undefined ? match : String(value);
+    }
+    return match;
+  });
+}

--- a/packages/lib/src/tryon/kv.ts
+++ b/packages/lib/src/tryon/kv.ts
@@ -6,12 +6,18 @@ type KvNamespace = {
   put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void>;
 };
 
+type GlobalWithKv = typeof globalThis & {
+  TRYON_KV?: KvNamespace;
+  env?: { TRYON_KV?: KvNamespace };
+  __env__?: { TRYON_KV?: KvNamespace };
+};
+
 function resolveKv(): KvNamespace | null {
   try {
-    const g = globalThis as unknown as Record<string, any>;
-    if (g.TRYON_KV && typeof g.TRYON_KV.get === 'function') return g.TRYON_KV as KvNamespace;
-    if (g.env && g.env.TRYON_KV && typeof g.env.TRYON_KV.get === 'function') return g.env.TRYON_KV as KvNamespace;
-    if (g.__env__ && g.__env__.TRYON_KV && typeof g.__env__.TRYON_KV.get === 'function') return g.__env__.TRYON_KV as KvNamespace;
+    const g = globalThis as GlobalWithKv;
+    if (g.TRYON_KV && typeof g.TRYON_KV.get === 'function') return g.TRYON_KV;
+    if (g.env && g.env.TRYON_KV && typeof g.env.TRYON_KV.get === 'function') return g.env.TRYON_KV;
+    if (g.__env__ && g.__env__.TRYON_KV && typeof g.__env__.TRYON_KV.get === 'function') return g.__env__.TRYON_KV;
     return null;
   } catch {
     return null;

--- a/packages/lib/src/tryon/providers/circuitBreaker.ts
+++ b/packages/lib/src/tryon/providers/circuitBreaker.ts
@@ -1,3 +1,5 @@
+import { t } from "../i18n";
+
 export type BreakerState = 'closed' | 'open' | 'half-open';
 
 interface Entry {
@@ -28,8 +30,8 @@ export function createBreaker(opts: { timeoutMs: number; failureThreshold: numbe
   async function withTimeout<T>(p: Promise<T>): Promise<T> {
     if (!timeoutMs || timeoutMs <= 0) return p;
     return new Promise<T>((resolve, reject) => {
-      const t = setTimeout(() => reject(new Error('timeout')), timeoutMs);
-      p.then((v) => { clearTimeout(t); resolve(v); }, (e) => { clearTimeout(t); reject(e); });
+      const timer = setTimeout(() => reject(new Error(t('tryon.circuitBreaker.timeout'))), timeoutMs);
+      p.then((v) => { clearTimeout(timer); resolve(v); }, (e) => { clearTimeout(timer); reject(e); });
     });
   }
 
@@ -44,7 +46,7 @@ export function createBreaker(opts: { timeoutMs: number; failureThreshold: numbe
 
       if (e.state === 'open') {
         if (nowMs < e.nextTryAt) {
-          throw new Error('circuit open');
+          throw new Error(t('tryon.circuitBreaker.open'));
         } else {
           e.state = 'half-open';
           e.inHalfOpen = false; // allow a single trial
@@ -53,7 +55,7 @@ export function createBreaker(opts: { timeoutMs: number; failureThreshold: numbe
 
       if (e.state === 'half-open') {
         if (e.inHalfOpen) {
-          throw new Error('circuit half-open');
+          throw new Error(t('tryon.circuitBreaker.halfOpen'));
         }
         e.inHalfOpen = true;
       }

--- a/packages/lib/src/tryon/providers/garment/managed.ts
+++ b/packages/lib/src/tryon/providers/garment/managed.ts
@@ -1,5 +1,6 @@
 import type { TryOnGenerator, TryOnProvider } from "../types";
 import type { ProviderResponse } from "@acme/types/tryon";
+import { t } from "../../i18n";
 
 async function postJson(url: string, body: unknown, headers: Record<string, string>): Promise<Response> {
   return fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(body) });
@@ -8,16 +9,20 @@ async function postJson(url: string, body: unknown, headers: Record<string, stri
 const generator: TryOnGenerator = {
   async run(opts) {
     const url = process.env.TRYON_HEAVY_API_URL;
-    if (!url) return { error: { code: 'PROVIDER_UNAVAILABLE', details: 'TRYON_HEAVY_API_URL not set' } };
+    if (!url) {
+      return { error: { code: 'PROVIDER_UNAVAILABLE', details: t('tryon.providers.garment.heavyApiUrlMissing') } };
+    }
     const idem = crypto.randomUUID();
     const res = await postJson(url, opts, { 'Idempotency-Key': idem });
-    if (!res.ok) return { error: { code: 'PROVIDER_UNAVAILABLE', details: `Upstream ${res.status}` } };
+    if (!res.ok) {
+      return { error: { code: 'PROVIDER_UNAVAILABLE', details: t('tryon.providers.garment.upstreamError', { status: res.status }) } };
+    }
     const ct = res.headers.get('content-type') || '';
     if (ct.includes('application/json')) {
       const data = await res.json().catch(() => ({}));
       if (data?.url) return { result: { url: data.url, width: data.width ?? 0, height: data.height ?? 0, expiresAt: data.expiresAt } } as ProviderResponse;
     }
-    return { error: { code: 'UNKNOWN', details: 'Unexpected upstream response' } };
+    return { error: { code: 'UNKNOWN', details: t('tryon.providers.garment.unexpectedResponse') } };
   },
 };
 


### PR DESCRIPTION
## Summary
- add a lightweight translation helper for try-on providers and replace hardcoded error strings with i18n keys
- tighten typings around the try-on KV resolver and Cloudflare request configuration to avoid `any`

## Testing
- pnpm --filter @acme/lib lint *(fails: @acme/eslint-plugin-ds missing dist build in this environment)*
- pnpm --filter @acme/lib build *(fails: packages/i18n/src/fr.json has existing JSON syntax issue)*

------
https://chatgpt.com/codex/tasks/task_e_68dbee685508832fbb6da214498460a4