### PR TITLE
Fix page builder overlay positioning lint errors

### DIFF
--- a/packages/ui/src/components/cms/page-builder/BlockResizer.tsx
+++ b/packages/ui/src/components/cms/page-builder/BlockResizer.tsx
@@ -22,7 +22,7 @@ export default function BlockResizer({
   const t = useTranslations();
   if (!selected) return null;
   return (
-    <>
+    <div className="pointer-events-none relative h-full w-full">
       {/* Rotate handle (top-center, slightly offset above) */}
       {startRotate && (
         <div
@@ -39,71 +39,71 @@ export default function BlockResizer({
           </div>
         </div>
       )}
-      <div onPointerDown={(e) => startResize(e, "nw")} role="button" tabIndex={0} aria-label="Resize from top-left" className="bg-primary absolute -top-2 -start-2 h-6 w-6 cursor-nwse-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-      <div onPointerDown={(e) => startResize(e, "ne")} role="button" tabIndex={0} aria-label="Resize from top-right" className="bg-primary absolute -top-2 -end-2 h-6 w-6 cursor-nesw-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-      <div onPointerDown={(e) => startResize(e, "sw")} role="button" tabIndex={0} aria-label="Resize from bottom-left" className="bg-primary absolute -bottom-2 -start-2 h-6 w-6 cursor-nesw-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-      <div onPointerDown={(e) => startResize(e, "se")} role="button" tabIndex={0} aria-label="Resize from bottom-right" className="bg-primary absolute -end-2 -bottom-2 h-6 w-6 cursor-nwse-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+      <div onPointerDown={(e) => startResize(e, "nw")} role="button" tabIndex={0} aria-label="Resize from top-left" className="pointer-events-auto bg-primary absolute -top-2 -start-2 h-6 w-6 cursor-nwse-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+      <div onPointerDown={(e) => startResize(e, "ne")} role="button" tabIndex={0} aria-label="Resize from top-right" className="pointer-events-auto bg-primary absolute -top-2 -end-2 h-6 w-6 cursor-nesw-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+      <div onPointerDown={(e) => startResize(e, "sw")} role="button" tabIndex={0} aria-label="Resize from bottom-left" className="pointer-events-auto bg-primary absolute -bottom-2 -start-2 h-6 w-6 cursor-nesw-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+      <div onPointerDown={(e) => startResize(e, "se")} role="button" tabIndex={0} aria-label="Resize from bottom-right" className="pointer-events-auto bg-primary absolute -end-2 -bottom-2 h-6 w-6 cursor-nwse-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
       {/* Side handles */}
-      <div onPointerDown={(e) => startResize(e, "n")} role="button" tabIndex={0} aria-label="Resize from top" className="bg-primary absolute -top-2 start-1/2 h-6 w-8 -translate-x-1/2 cursor-ns-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-      <div onPointerDown={(e) => startResize(e, "s")} role="button" tabIndex={0} aria-label="Resize from bottom" className="bg-primary absolute -bottom-2 start-1/2 h-6 w-8 -translate-x-1/2 cursor-ns-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-      <div onPointerDown={(e) => startResize(e, "w")} role="button" tabIndex={0} aria-label="Resize from left" className="bg-primary absolute top-1/2 -start-2 h-8 w-6 -translate-y-1/2 cursor-ew-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-      <div onPointerDown={(e) => startResize(e, "e")} role="button" tabIndex={0} aria-label="Resize from right" className="bg-primary absolute top-1/2 -end-2 h-8 w-6 -translate-y-1/2 cursor-ew-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+      <div onPointerDown={(e) => startResize(e, "n")} role="button" tabIndex={0} aria-label="Resize from top" className="pointer-events-auto bg-primary absolute -top-2 start-1/2 h-6 w-8 -translate-x-1/2 cursor-ns-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+      <div onPointerDown={(e) => startResize(e, "s")} role="button" tabIndex={0} aria-label="Resize from bottom" className="pointer-events-auto bg-primary absolute -bottom-2 start-1/2 h-6 w-8 -translate-x-1/2 cursor-ns-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+      <div onPointerDown={(e) => startResize(e, "w")} role="button" tabIndex={0} aria-label="Resize from left" className="pointer-events-auto bg-primary absolute top-1/2 -start-2 h-8 w-6 -translate-y-1/2 cursor-ew-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+      <div onPointerDown={(e) => startResize(e, "e")} role="button" tabIndex={0} aria-label="Resize from right" className="pointer-events-auto bg-primary absolute top-1/2 -end-2 h-8 w-6 -translate-y-1/2 cursor-ew-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
       <div
         onPointerDown={(e) => startSpacing(e, "margin", "top")}
         role="button"
         tabIndex={0}
         aria-label="Adjust margin top"
-        className="bg-primary absolute -top-3 start-1/2 h-2 w-10 -translate-x-1/2 cursor-n-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className="pointer-events-auto bg-primary absolute -top-3 start-1/2 h-2 w-10 -translate-x-1/2 cursor-n-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
       />
       <div
         onPointerDown={(e) => startSpacing(e, "margin", "bottom")}
         role="button"
         tabIndex={0}
         aria-label="Adjust margin bottom"
-        className="bg-primary absolute -bottom-3 start-1/2 h-2 w-10 -translate-x-1/2 cursor-s-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className="pointer-events-auto bg-primary absolute -bottom-3 start-1/2 h-2 w-10 -translate-x-1/2 cursor-s-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
       />
       <div
         onPointerDown={(e) => startSpacing(e, "margin", "left")}
         role="button"
         tabIndex={0}
         aria-label="Adjust margin left"
-        className="bg-primary absolute top-1/2 -left-3 h-10 w-2 -translate-y-1/2 cursor-w-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className="pointer-events-auto bg-primary absolute top-1/2 -left-3 h-10 w-2 -translate-y-1/2 cursor-w-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
       />
       <div
         onPointerDown={(e) => startSpacing(e, "margin", "right")}
         role="button"
         tabIndex={0}
         aria-label="Adjust margin right"
-        className="bg-primary absolute top-1/2 -right-3 h-10 w-2 -translate-y-1/2 cursor-e-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className="pointer-events-auto bg-primary absolute top-1/2 -right-3 h-10 w-2 -translate-y-1/2 cursor-e-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
       />
       <div
         onPointerDown={(e) => startSpacing(e, "padding", "top")}
         role="button"
         tabIndex={0}
         aria-label="Adjust padding top"
-        className="bg-primary absolute -top-1 start-1/2 h-2 w-10 -translate-x-1/2 cursor-n-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className="pointer-events-auto bg-primary absolute -top-1 start-1/2 h-2 w-10 -translate-x-1/2 cursor-n-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
       />
       <div
         onPointerDown={(e) => startSpacing(e, "padding", "bottom")}
         role="button"
         tabIndex={0}
         aria-label="Adjust padding bottom"
-        className="bg-primary absolute -bottom-1 start-1/2 h-2 w-10 -translate-x-1/2 cursor-s-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className="pointer-events-auto bg-primary absolute -bottom-1 start-1/2 h-2 w-10 -translate-x-1/2 cursor-s-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
       />
       <div
         onPointerDown={(e) => startSpacing(e, "padding", "left")}
         role="button"
         tabIndex={0}
         aria-label="Adjust padding left"
-        className="bg-primary absolute top-1/2 -left-1 h-10 w-2 -translate-y-1/2 cursor-w-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className="pointer-events-auto bg-primary absolute top-1/2 -left-1 h-10 w-2 -translate-y-1/2 cursor-w-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
       />
       <div
         onPointerDown={(e) => startSpacing(e, "padding", "right")}
         role="button"
         tabIndex={0}
         aria-label="Adjust padding right"
-        className="bg-primary absolute top-1/2 -end-1 h-10 w-2 -translate-y-1/2 cursor-e-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        className="pointer-events-auto bg-primary absolute top-1/2 -end-1 h-10 w-2 -translate-y-1/2 cursor-e-resize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
       />
-    </>
+    </div>
   );
 }

--- a/packages/ui/src/components/cms/page-builder/CommentsThreadList.tsx
+++ b/packages/ui/src/components/cms/page-builder/CommentsThreadList.tsx
@@ -148,20 +148,20 @@ export default function CommentsThreadList({
           <ul>
             {filtered.map((thr) => {
               // i18n-exempt -- TECH-000 [ttl=2025-10-28] styling only; no user-facing copy in this line
-              const rowClass = `cursor-pointer border-b p-2 text-sm hover:bg-surface-3 ${selectedId === thr.id ? "bg-surface-2" : ""} ${flashId === thr.id ? "animate-pulse ring-2 ring-primary" : ""}`;
+              const rowClass = `border-b p-2 text-sm hover:bg-surface-3 ${selectedId === thr.id ? "bg-surface-2" : ""} ${flashId === thr.id ? "animate-pulse ring-2 ring-primary" : ""}`;
               return (
-              <li
-                key={thr.id}
-                ref={(el) => {
-                  rowsRef.current[thr.id] = el;
-                }}
-                className={rowClass}
-                onClick={() => onSelect(thr.id)}
-              >
-                <button
-                  type="button"
-                  className="block w-full min-h-10 min-w-10 text-start"
+                <li
+                  key={thr.id}
+                  ref={(el) => {
+                    rowsRef.current[thr.id] = el;
+                  }}
+                  className={rowClass}
                 >
+                  <button
+                    type="button"
+                    className="block w-full min-h-10 min-w-10 cursor-pointer text-start"
+                    onClick={() => onSelect(thr.id)}
+                  >
                   {/** i18n-exempt */}
                   <Cluster alignY="center" justify="between">
                     <div className="truncate font-medium">{thr.componentId}</div>
@@ -174,9 +174,10 @@ export default function CommentsThreadList({
                     <span>{thr.assignedTo ? `@${thr.assignedTo}` : (t("cms.builder.comments.unassigned") as string)}</span>
                     <span>{formatTime(thr.updatedAt ?? thr.createdAt)}</span>
                   </Cluster>
-                </button>
-              </li>
-            );})}
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/packages/ui/src/components/cms/page-builder/GridOverlay.tsx
+++ b/packages/ui/src/components/cms/page-builder/GridOverlay.tsx
@@ -11,24 +11,26 @@ const GridOverlay = ({ gridCols, gutter, baselineStep }: Props) => {
   const cols =
     Number.isFinite(gridCols) && gridCols > 0 ? Math.floor(gridCols) : 1;
   return (
-    <div
-      className="pointer-events-none absolute inset-0"
-      data-cy={/* i18n-exempt -- PB-2416 */ "pb-grid-overlay"}
-      style={{
-        display: "grid",
-        gridTemplateColumns: `repeat(${cols}, 1fr)`,
-        ...(gutter ? { columnGap: gutter } : {}),
-        ...(baselineStep && baselineStep > 0
-          ? {
-              backgroundImage: `repeating-linear-gradient(to bottom, hsl(var(--muted-foreground, 0 0% 45%)/.35) 0, hsl(var(--muted-foreground, 0 0% 45%)/.35) 1px, transparent 1px, transparent ${baselineStep}px)`,
-            }
-          : {}),
-      }}
-    >
-      {Array.from({ length: cols }).map((_, i) => (
-        // eslint-disable-next-line react/no-array-index-key -- PB-2416: column order fixed, purely decorative
-        <div key={i} className="border-muted-foreground/40 border-l border-dashed" />
-      ))}
+    <div className="pointer-events-none relative">
+      <div
+        className="absolute inset-0"
+        data-cy={/* i18n-exempt -- PB-2416 */ "pb-grid-overlay"}
+        style={{
+          display: "grid",
+          gridTemplateColumns: `repeat(${cols}, 1fr)`,
+          ...(gutter ? { columnGap: gutter } : {}),
+          ...(baselineStep && baselineStep > 0
+            ? {
+                backgroundImage: `repeating-linear-gradient(to bottom, hsl(var(--muted-foreground, 0 0% 45%)/.35) 0, hsl(var(--muted-foreground, 0 0% 45%)/.35) 1px, transparent 1px, transparent ${baselineStep}px)`,
+              }
+            : {}),
+        }}
+      >
+        {Array.from({ length: cols }).map((_, i) => (
+          // eslint-disable-next-line react/no-array-index-key -- PB-2416: column order fixed, purely decorative
+          <div key={i} className="border-muted-foreground/40 border-l border-dashed" />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- wrap the block resizer handles in a positioned container and keep them interactive to satisfy the absolute-parent lint rule
- move the comments thread row click handler onto the button element to clear the jsx-a11y warnings
- give the grid overlay a relative wrapper so its absolute grid tracks a positioned ancestor

## Testing
- pnpm --filter @acme/ui lint *(fails: missing @acme/eslint-plugin-ds in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbeebdfeac832f997a2651a6d6463f