### PR TITLE
fix: await expectations in upload panel stories

### DIFF
--- a/packages/ui/src/components/cms/media/UploadPanel.stories.tsx
+++ b/packages/ui/src/components/cms/media/UploadPanel.stories.tsx
@@ -63,9 +63,13 @@ export const UploadingState: Story = {
       });
 
       await userEvent.click(uploadButton);
-      expect(uploadButton).toBeDisabled();
-      await waitFor(() => expect(uploadButton).not.toBeDisabled());
-      await waitFor(() => expect(onUploaded).toHaveBeenCalled());
+      await expect(uploadButton).toBeDisabled();
+      await waitFor(async () => {
+        await expect(uploadButton).not.toBeDisabled();
+      });
+      await waitFor(async () => {
+        await expect(onUploaded).toHaveBeenCalled();
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -101,7 +105,9 @@ export const UploadError: Story = {
 
       await userEvent.click(uploadButton);
       await canvas.findByText("Upload failed");
-      await waitFor(() => expect(onUploadError).toHaveBeenCalledWith("Upload failed"));
+      await waitFor(async () => {
+        await expect(onUploadError).toHaveBeenCalledWith("Upload failed");
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
## Summary
- ensure UploadPanel stories await expectations and waitFor callbacks
- align interaction tests with Storybook guidance for userEvent and expect usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbfaf0d22c832fa5fea0ae5267bfc5