### PR TITLE
Add comprehensive tests for badge, price, logo, and AR viewer

### DIFF
--- a/packages/ui/__tests__/ARViewer.test.tsx
+++ b/packages/ui/__tests__/ARViewer.test.tsx
@@ -26,5 +26,22 @@ describe("ARViewer", () => {
     unmount();
     (customElements as any).get = getOrig;
   });
+
+  it("uses configured script source when provided", () => {
+    const getOrig = customElements.get;
+    const originalEnv = process.env.NEXT_PUBLIC_MODEL_VIEWER_SRC;
+    (customElements as any).get = jest.fn(() => undefined);
+    process.env.NEXT_PUBLIC_MODEL_VIEWER_SRC = "https://cdn.example.com/model-viewer.js";
+
+    const { unmount } = render(<ARViewer src="/custom.glb" />);
+    const script = document.head.querySelector(
+      "script[src='https://cdn.example.com/model-viewer.js']",
+    );
+    expect(script).not.toBeNull();
+
+    unmount();
+    process.env.NEXT_PUBLIC_MODEL_VIEWER_SRC = originalEnv;
+    (customElements as any).get = getOrig;
+  });
 });
 

--- a/packages/ui/__tests__/Logo.test.tsx
+++ b/packages/ui/__tests__/Logo.test.tsx
@@ -48,4 +48,32 @@ describe("Logo", () => {
     img = container.querySelector("img")!;
     expect(img.getAttribute("src")).toBe("/mobile.png");
   });
+
+  it("deduplicates identical sources when computing srcSet", () => {
+    mockViewport.mockReturnValue("desktop");
+    const { container } = render(
+      <Logo
+        fallbackText="ACME"
+        src="/shared.png"
+        sources={{ mobile: { src: "/shared.png", width: 80 } }}
+      />,
+    );
+    const img = container.querySelector("img")!;
+    const parts = img.getAttribute("srcset")!.split(",");
+    expect(parts).toHaveLength(1);
+    expect(parts[0].trim()).toBe("/shared.png 32w");
+  });
+
+  it("respects provided srcSet overrides", () => {
+    mockViewport.mockReturnValue("desktop");
+    const { container } = render(
+      <Logo
+        fallbackText="ACME"
+        src="/logo.png"
+        srcSet="/logo.png 1x, /logo@2x.png 2x"
+      />,
+    );
+    const img = container.querySelector("img")!;
+    expect(img.getAttribute("srcset")).toBe("/logo.png 1x, /logo@2x.png 2x");
+  });
 });

--- a/packages/ui/__tests__/Price.test.tsx
+++ b/packages/ui/__tests__/Price.test.tsx
@@ -1,9 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import { Price } from "../src/components/atoms/Price";
 
+const mockUseCurrency = jest.fn();
+
 jest.mock("@acme/platform-core/contexts/CurrencyContext", () => ({
-  useCurrency: () => ["EUR", jest.fn()],
+  useCurrency: () => mockUseCurrency(),
 }));
+
+beforeEach(() => {
+  mockUseCurrency.mockReturnValue(["EUR", jest.fn()]);
+});
 
 describe("Price", () => {
   it("formats amount with provided currency and applies class names", () => {
@@ -17,5 +23,11 @@ describe("Price", () => {
     render(<Price amount={1234.56} aria-label="price" />);
     const span = screen.getByLabelText("price");
     expect(span).toHaveTextContent("€1,234.56");
+  });
+
+  it("uses EUR as a hard fallback when context currency is unavailable", () => {
+    mockUseCurrency.mockReturnValue([undefined, jest.fn()]);
+    render(<Price amount={10} />);
+    expect(screen.getByText("€10.00")).toBeInTheDocument();
   });
 });

--- a/packages/ui/__tests__/ProductBadge.test.tsx
+++ b/packages/ui/__tests__/ProductBadge.test.tsx
@@ -13,6 +13,46 @@ describe("ProductBadge", () => {
     rerender(<ProductBadge label="New" variant="new" />);
     outer = screen.getByText("New").parentElement as HTMLElement;
     expect(outer).toHaveAttribute("data-token", "--color-success");
+    expect(screen.getByText("New")).toHaveClass("text-success-fg");
+
+    rerender(<ProductBadge label="Regular" variant="default" />);
+    outer = screen.getByText("Regular").parentElement as HTMLElement;
+    expect(outer).toHaveAttribute("data-token", "--color-muted");
+  });
+
+  it("prefers explicit color overrides and soft tone by default", () => {
+    const { rerender } = render(
+      <ProductBadge label="Info" color="info" className="extra" />,
+    );
+    const infoInner = screen.getByText("Info");
+    let outer = infoInner.parentElement as HTMLElement;
+    expect(outer).toHaveAttribute("data-token", "--color-info-soft");
+    expect(outer.className).toMatch(/bg-info-soft/);
+    expect(infoInner).toHaveClass("text-fg");
+    expect(outer.className).toMatch(/extra/);
+
+    rerender(
+      <ProductBadge label="Primary" color="primary" tone="solid" />,
+    );
+    const primaryInner = screen.getByText("Primary");
+    outer = primaryInner.parentElement as HTMLElement;
+    expect(outer).toHaveAttribute("data-token", "--color-primary");
+    expect(outer.className).toMatch(/bg-primary(\s|$)/);
+    expect(primaryInner).toHaveClass("text-primary-foreground");
+  });
+
+  it("uses provided tone even when variant is unset", () => {
+    const badge = render(
+      <ProductBadge
+        // @ts-expect-error intentionally unset to exercise tone fallback branch
+        variant={undefined}
+        label="Custom"
+        tone="soft"
+      />,
+    );
+    const outer = badge.getByText("Custom").parentElement as HTMLElement;
+    expect(outer).toHaveAttribute("data-token", "--color-muted");
+    expect(outer.className).toMatch(/bg-muted/);
   });
 });
 


### PR DESCRIPTION
## Summary
- expand `ProductBadge` tests to cover tone, color, and variant fallbacks
- add `Price` coverage for currency context fallbacks and hard default handling
- exercise `ARViewer` and `Logo` branches for custom script source, srcset deduplication, and overrides

## Testing
- pnpm --filter @acme/ui exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --runTestsByPath __tests__/ProductBadge.test.tsx __tests__/Price.test.tsx __tests__/ARViewer.test.tsx __tests__/Logo.test.tsx --coverage=false


------
https://chatgpt.com/codex/tasks/task_e_68dbf8fc6cb0832fb6a35da34a744e7b