### PR TITLE
test(ui): cover breadcrumbs, zoom image, theme style, grid

### DIFF
--- a/packages/ui/__tests__/Breadcrumbs.test.tsx
+++ b/packages/ui/__tests__/Breadcrumbs.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { render, screen } from "@testing-library/react";
 import Breadcrumbs from "../src/components/molecules/Breadcrumbs";
 
@@ -16,5 +17,23 @@ describe("Breadcrumbs", () => {
 
     const separators = screen.getAllByText("/");
     expect(separators).toHaveLength(2);
+  });
+
+  it("falls back to generated keys when labels are complex nodes", () => {
+    const items = [
+      { label: <strong>Overview</strong> },
+      { label: <em>Details</em> },
+    ];
+
+    const { container } = render(<Breadcrumbs items={items} />);
+
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByText("Details")).toBeInTheDocument();
+
+    // No anchors should be rendered because there are no href values
+    expect(container.querySelectorAll("a")).toHaveLength(0);
+
+    // Ensure the separator renders between the generated breadcrumb wrappers
+    expect(screen.getAllByText("/")).toHaveLength(1);
   });
 });

--- a/packages/ui/__tests__/Grid.primitives.test.tsx
+++ b/packages/ui/__tests__/Grid.primitives.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Grid } from "../src/components/atoms/primitives/Grid";
+
+describe("Grid primitive", () => {
+  it("renders with default column and gap classes", () => {
+    render(<Grid data-cy="grid" />);
+    const grid = screen.getByTestId("grid");
+    expect(grid.className).toContain("grid");
+    expect(grid.className).toContain("grid-cols-2");
+    expect(grid.className).toContain("gap-4");
+  });
+
+  it("merges custom column, gap, and className values", () => {
+    render(
+      <Grid data-testid="grid" cols={5} gap={1} className="bg-muted" aria-label="layout" />
+    );
+    const grid = screen.getByLabelText("layout");
+    expect(grid.className).toContain("grid-cols-5");
+    expect(grid.className).toContain("gap-1");
+    expect(grid.className).toContain("bg-muted");
+  });
+});

--- a/packages/ui/__tests__/ThemeStyle.test.tsx
+++ b/packages/ui/__tests__/ThemeStyle.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ThemeStyle from "../src/components/ThemeStyle";
+import { readShop } from "@acme/platform-core/repositories/shops.server";
+
+jest.mock("@acme/platform-core/repositories/shops.server", () => ({
+  readShop: jest.fn(),
+}));
+
+const mockReadShop = readShop as jest.MockedFunction<typeof readShop>;
+
+describe("ThemeStyle", () => {
+  beforeEach(() => {
+    mockReadShop.mockReset();
+  });
+
+  it("returns null when no shop or token data is provided", async () => {
+    const result = await ThemeStyle({});
+    expect(result).toBeNull();
+    expect(mockReadShop).not.toHaveBeenCalled();
+  });
+
+  it("renders theme styles and Google Fonts from shop data", async () => {
+    mockReadShop.mockResolvedValue({
+      themeTokens: {
+        "--font-body": '"Inter", sans-serif',
+        "--font-heading-1": '"Roboto"',
+        "--font-heading-2": "var(--font-custom), Arial",
+        "--color-accent": "#123456",
+      },
+    } as any);
+
+    const element = await ThemeStyle({ shopId: "shop-123" });
+    expect(mockReadShop).toHaveBeenCalledWith("shop-123");
+    expect(element).not.toBeNull();
+
+    const html = renderToStaticMarkup(element!);
+
+    expect(html).toContain("data-shop-theme");
+    expect(html).toContain("--font-sans: var(--font-body);");
+    expect(html).toContain("family=Inter&amp;display=swap");
+    expect(html).toContain("family=Roboto&amp;display=swap");
+    expect(html).not.toContain("family=Arial");
+  });
+
+  it("returns null for an explicit empty token set", async () => {
+    const element = await ThemeStyle({ tokens: {} });
+    expect(mockReadShop).not.toHaveBeenCalled();
+    expect(element).toBeNull();
+  });
+});

--- a/packages/ui/__tests__/ZoomImage.test.tsx
+++ b/packages/ui/__tests__/ZoomImage.test.tsx
@@ -19,5 +19,23 @@ describe("ZoomImage", () => {
     expect(img.className).toMatch(/scale-125/);
     expect((img as any).style.transform).toBe("scale(1.5)");
   });
+
+  it("supports keyboard toggles and falls back to an empty alt", () => {
+    render(<ZoomImage src="/b.jpg" width={50} height={50} />);
+
+    const figure = screen.getByRole("button");
+    const img = figure.querySelector("img") as HTMLImageElement;
+
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute("alt", "");
+    expect(figure).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.keyDown(figure, { key: "Enter" });
+    expect(figure).toHaveAttribute("aria-pressed", "true");
+    expect(figure.className).toMatch(/cursor-zoom-out/);
+
+    fireEvent.keyDown(figure, { key: " " });
+    expect(figure).toHaveAttribute("aria-pressed", "false");
+  });
 });
 


### PR DESCRIPTION
## Summary
- add coverage for generated breadcrumb keys when labels are non-string nodes
- extend ZoomImage tests for keyboard toggling and alt fallback behavior
- add ThemeStyle server-side tests to exercise fetch, token, and font-link logic
- cover Grid primitive defaults and overrides to validate class name composition

## Testing
- pnpm --filter @acme/ui exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --runTestsByPath __tests__/Breadcrumbs.test.tsx __tests__/ZoomImage.test.tsx __tests__/ThemeStyle.test.tsx __tests__/Grid.primitives.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dbf8e3440c832fa79de14e0f5ae1e1