### PR TITLE
Add tests for try-on analytics and gating components

### DIFF
--- a/packages/ui/src/components/ab/__tests__/ExperimentGate.test.tsx
+++ b/packages/ui/src/components/ab/__tests__/ExperimentGate.test.tsx
@@ -1,0 +1,73 @@
+// packages/ui/src/components/ab/__tests__/ExperimentGate.test.tsx
+import { render, screen, waitFor } from "@testing-library/react";
+import ExperimentGate from "../ExperimentGate";
+
+describe("ExperimentGate", () => { // i18n-exempt: test titles
+  const baseUrl = window.location.origin;
+
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.replaceState({}, "", `${baseUrl}/`);
+  });
+
+  test("prefers explicit enabled prop when provided", async () => { // i18n-exempt: test title
+    const { rerender } = render(
+      <ExperimentGate enabled fallback={<span>off</span>}>
+        <span>on</span>
+      </ExperimentGate>
+    );
+
+    expect(screen.getByText("on")).toBeInTheDocument();
+
+    rerender(
+      <ExperimentGate enabled={false} fallback={<span>off</span>}>
+        <span>on</span>
+      </ExperimentGate>
+    );
+
+    await waitFor(() => expect(screen.getByText("off")).toBeInTheDocument());
+    expect(screen.queryByText("on")).not.toBeInTheDocument();
+  });
+
+  test("reads query parameter overrides and persists to localStorage", async () => { // i18n-exempt: test title
+    window.history.replaceState({}, "", `${baseUrl}/product?exp-demo=off`);
+
+    render(
+      <ExperimentGate flag="demo" fallback={<span>off</span>}>
+        <span>on</span>
+      </ExperimentGate>
+    );
+
+    await waitFor(() => expect(screen.getByText("off")).toBeInTheDocument());
+    expect(localStorage.getItem("exp:demo")).toBe("off");
+  });
+
+  test("falls back to stored preference when query parameter is absent", async () => { // i18n-exempt: test title
+    localStorage.setItem("exp:demo", "on");
+
+    render(
+      <ExperimentGate flag="demo" fallback={<span>off</span>}>
+        <span>on</span>
+      </ExperimentGate>
+    );
+
+    await waitFor(() => expect(screen.getByText("on")).toBeInTheDocument());
+  });
+
+  test("ignores errors when resolving overrides", async () => { // i18n-exempt: test title
+    const originalURL = window.URL;
+    window.URL = jest.fn(() => {
+      throw new Error("bad url");
+    }) as unknown as typeof URL;
+
+    render(
+      <ExperimentGate flag="demo" fallback={<span>off</span>}>
+        <span>on</span>
+      </ExperimentGate>
+    );
+
+    await waitFor(() => expect(screen.getByText("on")).toBeInTheDocument());
+
+    window.URL = originalURL;
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/StoreLocatorMap.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/StoreLocatorMap.test.tsx
@@ -1,0 +1,100 @@
+// packages/ui/src/components/organisms/__tests__/StoreLocatorMap.test.tsx
+import { render, waitFor } from "@testing-library/react";
+import { StoreLocatorMap } from "../StoreLocatorMap";
+
+describe("StoreLocatorMap", () => { // i18n-exempt: test titles
+  afterEach(() => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+    delete (window as { L?: unknown }).L;
+  });
+
+  test("loads Leaflet assets and renders markers", async () => { // i18n-exempt: test title
+    const mapInstance: any = { remove: jest.fn() };
+    mapInstance.setView = jest.fn(() => mapInstance);
+
+    const tileAddTo = jest.fn();
+    const markerBindPopup = jest.fn();
+    const markerAddTo = jest.fn(() => ({ bindPopup: markerBindPopup }));
+
+    const L = {
+      map: jest.fn(() => mapInstance),
+      tileLayer: jest.fn(() => ({ addTo: tileAddTo })),
+      marker: jest.fn(() => ({ addTo: markerAddTo })),
+    };
+
+    const appendHead = jest.spyOn(document.head, "appendChild");
+    const appendBody = jest.spyOn(document.body, "appendChild");
+    let scriptEl: HTMLScriptElement | null = null;
+    appendBody.mockImplementation((node: Node) => {
+      if (node instanceof HTMLScriptElement) {
+        scriptEl = node;
+      }
+      return Node.prototype.appendChild.call(document.body, node);
+    });
+
+    const { unmount } = render(
+      <StoreLocatorMap
+        locations={[
+          { lat: 1, lng: 2, label: "A" },
+          { lat: 3, lng: 4 },
+        ]}
+        zoom={7}
+        className="extra"
+      />
+    );
+
+    expect(appendHead).toHaveBeenCalled();
+    expect(appendBody).toHaveBeenCalled();
+
+    (window as { L?: typeof L }).L = L;
+    scriptEl?.onload?.(new Event("load"));
+
+    await waitFor(() => expect(L.map).toHaveBeenCalled());
+    expect(L.map).toHaveBeenCalledWith(expect.any(HTMLElement));
+    expect(mapInstance.setView).toHaveBeenCalledWith([1, 2], 7);
+    expect(tileAddTo).toHaveBeenCalledWith(mapInstance);
+    expect(markerAddTo).toHaveBeenCalledTimes(2);
+    expect(markerBindPopup).toHaveBeenNthCalledWith(1, "A");
+    expect(markerBindPopup).toHaveBeenNthCalledWith(2, "");
+
+    unmount();
+    expect(mapInstance.remove).toHaveBeenCalled();
+
+    appendHead.mockRestore();
+    appendBody.mockRestore();
+  });
+
+  test("skips initialization when no locations are provided", () => { // i18n-exempt: test title
+    (window as { L?: unknown }).L = {
+      map: jest.fn(),
+      tileLayer: jest.fn(() => ({ addTo: jest.fn() })),
+      marker: jest.fn(() => ({ addTo: jest.fn(() => ({ bindPopup: jest.fn() })) })),
+    };
+
+    render(<StoreLocatorMap locations={[]} />);
+
+    expect(((window as { L?: any }).L as any).map).not.toHaveBeenCalled();
+  });
+
+  test("prefers legacy height prop when provided", () => { // i18n-exempt: test title
+    (window as { L?: unknown }).L = {
+      map: jest.fn(() => ({ setView: jest.fn(() => ({ remove: jest.fn() })) })),
+      tileLayer: jest.fn(() => ({ addTo: jest.fn() })),
+      marker: jest.fn(() => ({ addTo: jest.fn(() => ({ bindPopup: jest.fn() })) })),
+    };
+
+    const { container } = render(
+      <StoreLocatorMap
+        locations={[{ lat: 1, lng: 1 }]}
+        height="h-24"
+        heightClass="h-96"
+        className="extra"
+      />
+    );
+
+    expect(container.firstChild).toHaveClass("h-24");
+    expect(container.firstChild).toHaveClass("w-full");
+    expect(container.firstChild).toHaveClass("extra");
+  });
+});

--- a/packages/ui/src/hooks/tryon/__tests__/analytics.test.ts
+++ b/packages/ui/src/hooks/tryon/__tests__/analytics.test.ts
@@ -1,0 +1,115 @@
+// packages/ui/src/hooks/tryon/__tests__/analytics.test.ts
+import type { TryOnCtx } from "../analytics";
+
+describe("try-on analytics storage helpers", () => { // i18n-exempt: test titles
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    window.sessionStorage.clear();
+  });
+
+  test("getTryOnCtx falls back to sessionStorage when memory is empty", async () => { // i18n-exempt: test title
+    jest.resetModules();
+    const analytics = await import("../analytics");
+    analytics.clearTryOnCtx();
+    window.sessionStorage.setItem("tryon.ctx", JSON.stringify({ productId: "from-storage", mode: "garment" } satisfies TryOnCtx));
+
+    const ctx = analytics.getTryOnCtx();
+    expect(ctx).toEqual({ productId: "from-storage", mode: "garment" });
+    expect(ctx).not.toBe(analytics.getTryOnCtx());
+  });
+
+  test("setTryOnCtx merges with existing context and writes to storage", async () => { // i18n-exempt: test title
+    jest.resetModules();
+    const analytics = await import("../analytics");
+    analytics.clearTryOnCtx();
+    window.sessionStorage.clear();
+
+    const first = analytics.setTryOnCtx({ productId: "p1" });
+    expect(first).toEqual({ productId: "p1" });
+
+    const second = analytics.setTryOnCtx({ mode: "garment" });
+    expect(second).toEqual({ productId: "p1", mode: "garment" });
+    expect(JSON.parse(window.sessionStorage.getItem("tryon.ctx") || "{}")).toEqual(second);
+  });
+
+  test("clearTryOnCtx resets memory even when storage removal fails", async () => { // i18n-exempt: test title
+    jest.resetModules();
+    const analytics = await import("../analytics");
+    analytics.setTryOnCtx({ productId: "keep-me" });
+    const originalRemove = window.sessionStorage.removeItem;
+    window.sessionStorage.removeItem = jest.fn(() => {
+      throw new Error("boom");
+    });
+
+    analytics.clearTryOnCtx();
+    expect(analytics.getTryOnCtx()).toEqual({});
+
+    window.sessionStorage.removeItem = originalRemove;
+  });
+
+  test("logTryOnEvent posts payloads and ignores fetch failures", async () => { // i18n-exempt: test title
+    jest.resetModules();
+    const analytics = await import("../analytics");
+    analytics.clearTryOnCtx();
+    analytics.setTryOnCtx({ productId: "p1", mode: "garment", idempotencyKey: "idem" });
+
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    // @ts-expect-error: assigning test stub
+    global.fetch = fetchMock;
+    await analytics.logTryOnEvent("TryOnEnhanced", { extra: "value" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/analytics/tryon",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: "TryOnEnhanced",
+          productId: "p1",
+          mode: "garment",
+          idempotencyKey: "idem",
+          extra: "value",
+        }),
+      })
+    );
+
+    fetchMock.mockRejectedValueOnce(new Error("network"));
+    await analytics.logTryOnEvent("TryOnError", { code: "500" });
+  });
+
+  test("handles execution when window is unavailable", async () => { // i18n-exempt: test title
+    const originalWindow = global.window;
+    // @ts-expect-error: simulate server runtime
+    delete global.window;
+
+    jest.resetModules();
+    const analytics = await import("../analytics");
+    expect(analytics.getTryOnCtx()).toEqual({});
+    expect(analytics.setTryOnCtx({ productId: "p2" })).toEqual({ productId: "p2" });
+    analytics.clearTryOnCtx();
+
+    global.window = originalWindow;
+  });
+
+  test("read/write operations swallow storage exceptions", async () => { // i18n-exempt: test title
+    jest.resetModules();
+    const analytics = await import("../analytics");
+    analytics.clearTryOnCtx();
+
+    const originalGetItem = window.sessionStorage.getItem;
+    window.sessionStorage.getItem = jest.fn(() => {
+      throw new Error("get fail");
+    });
+    expect(analytics.getTryOnCtx()).toEqual({});
+    window.sessionStorage.getItem = originalGetItem;
+
+    const originalSetItem = window.sessionStorage.setItem;
+    window.sessionStorage.setItem = jest.fn(() => {
+      throw new Error("set fail");
+    });
+    expect(analytics.setTryOnCtx({ mode: "accessory" })).toEqual({ mode: "accessory" });
+    window.sessionStorage.setItem = originalSetItem;
+  });
+});

--- a/packages/ui/src/hooks/tryon/__tests__/useTryOnAnalytics.test.tsx
+++ b/packages/ui/src/hooks/tryon/__tests__/useTryOnAnalytics.test.tsx
@@ -1,0 +1,98 @@
+// packages/ui/src/hooks/tryon/__tests__/useTryOnAnalytics.test.tsx
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { UseTryOnAnalyticsOptions } from "../useTryOnAnalytics";
+import { useTryOnAnalytics } from "../useTryOnAnalytics";
+
+const mockUseParams = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useParams: () => mockUseParams(),
+}));
+
+jest.mock("../analytics", () => ({
+  getTryOnCtx: jest.fn(() => ({ productId: "ctx-product", mode: "accessory" })),
+  setTryOnCtx: jest.fn(),
+  logTryOnEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { getTryOnCtx, setTryOnCtx, logTryOnEvent } from "../analytics";
+
+describe("useTryOnAnalytics", () => { // i18n-exempt: test titles
+  const mockGetTryOnCtx = getTryOnCtx as jest.MockedFunction<typeof getTryOnCtx>;
+  const mockSetTryOnCtx = setTryOnCtx as jest.MockedFunction<typeof setTryOnCtx>;
+  const mockLogTryOnEvent = logTryOnEvent as jest.MockedFunction<typeof logTryOnEvent>;
+
+  beforeEach(() => {
+    mockUseParams.mockReset();
+    mockGetTryOnCtx.mockClear();
+    mockSetTryOnCtx.mockClear();
+    mockLogTryOnEvent.mockClear();
+    mockLogTryOnEvent.mockResolvedValue(undefined);
+    mockGetTryOnCtx.mockReturnValue({ productId: "ctx-product", mode: "accessory" });
+  });
+
+  test("infers slug from params and exposes helpers", async () => { // i18n-exempt: test title
+    mockUseParams.mockReturnValue({ slug: "route-slug" });
+
+    const { result } = renderHook(() => useTryOnAnalytics());
+
+    await waitFor(() =>
+      expect(mockSetTryOnCtx).toHaveBeenCalledWith({ productId: "route-slug", mode: "accessory" })
+    );
+
+    expect(result.current.ctx).toEqual({ productId: "ctx-product", mode: "accessory" });
+    expect(result.current.setCtx).toBe(mockSetTryOnCtx);
+
+    await act(async () => {
+      result.current.clear();
+    });
+    expect(mockSetTryOnCtx).toHaveBeenLastCalledWith({
+      productId: undefined,
+      mode: undefined,
+      idempotencyKey: undefined,
+    });
+  });
+
+  test("respects explicit productId and mode overrides", async () => { // i18n-exempt: test title
+    mockUseParams.mockReturnValue({ slug: ["ignored", "second"] });
+
+    const opts: UseTryOnAnalyticsOptions = { productId: "override", mode: "garment" };
+    renderHook(() => useTryOnAnalytics(opts));
+
+    await waitFor(() =>
+      expect(mockSetTryOnCtx).toHaveBeenCalledWith({ productId: "override", mode: "garment" })
+    );
+  });
+
+  test("handles missing slug and triggers analytics events", async () => { // i18n-exempt: test title
+    mockUseParams.mockReturnValue(null);
+
+    const { result } = renderHook(() => useTryOnAnalytics());
+
+    // No slug means the setup effect should not push a product id
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockSetTryOnCtx).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.started();
+      await result.current.started("idem-1");
+      await result.current.previewShown();
+      await result.current.previewShown(1200);
+      await result.current.enhanced();
+      await result.current.enhanced(2200);
+      await result.current.addToCart();
+      await result.current.addToCart({ color: "black" });
+      await result.current.error("ERR_CODE", "Readable message");
+    });
+
+    expect(mockSetTryOnCtx).toHaveBeenCalledWith({ idempotencyKey: "idem-1" });
+    expect(mockLogTryOnEvent).toHaveBeenCalledWith("TryOnStarted");
+    expect(mockLogTryOnEvent).toHaveBeenCalledWith("TryOnPreviewShown", undefined);
+    expect(mockLogTryOnEvent).toHaveBeenCalledWith("TryOnPreviewShown", { preprocessMs: 1200 });
+    expect(mockLogTryOnEvent).toHaveBeenCalledWith("TryOnEnhanced", undefined);
+    expect(mockLogTryOnEvent).toHaveBeenCalledWith("TryOnEnhanced", { generateMs: 2200 });
+    expect(mockLogTryOnEvent).toHaveBeenCalledWith("TryOnAddToCart", undefined);
+    expect(mockLogTryOnEvent).toHaveBeenCalledWith("TryOnAddToCart", { transform: { color: "black" } });
+    expect(mockLogTryOnEvent).toHaveBeenCalledWith("TryOnError", { code: "ERR_CODE", message: "Readable message" });
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for the try-on analytics helpers, including storage fallbacks and fetch logging
- exercise the `useTryOnAnalytics` hook to verify slug inference, overrides, and event helpers
- cover the `ExperimentGate` and `StoreLocatorMap` components, including error handling and Leaflet integration

## Testing
- `pnpm --filter @acme/ui test -- --testPathPattern "(tryon|ExperimentGate|StoreLocatorMap)"` *(fails repository-wide coverage threshold, but targeted suites pass)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf8c25e0c832f99693090571eceec