### PR TITLE
Align primitive stories with composition guidance

### DIFF
--- a/packages/ui/src/components/atoms/primitives/Card.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Card.stories.tsx
@@ -1,9 +1,10 @@
 import { type Meta, type StoryObj } from "@storybook/react";
 import { Card, CardContent } from "./card";
 
-const meta: Meta<typeof Card> = {
+const meta = {
   title: "Primitives/Card",
   component: Card,
+  subcomponents: { CardContent },
   decorators: [
     (Story) => (
       <div className="grid gap-4 p-8 @md:grid-cols-2">
@@ -11,22 +12,34 @@ const meta: Meta<typeof Card> = {
       </div>
     ),
   ],
-};
+} satisfies Meta<typeof Card>;
 export default meta;
 
-export const Surfaces: StoryObj<typeof Card> = {
+type Story = StoryObj<typeof meta>;
+
+const surfaceExamples = [
+  {
+    id: "default",
+    elevated: false,
+    label: "Default panel surface",
+  },
+  {
+    id: "elevated",
+    elevated: true,
+    label: "Elevated surface (surface-3)",
+  },
+];
+
+export const SurfaceComparison: Story = {
   render: () => (
     <>
-      <Card>
-        <CardContent>
-          <div className="text-sm">Default panel surface</div>
-        </CardContent>
-      </Card>
-      <Card elevated>
-        <CardContent>
-          <div className="text-sm">Elevated surface (surface-3)</div>
-        </CardContent>
-      </Card>
+      {surfaceExamples.map(({ id, elevated, label }) => (
+        <Card key={id} elevated={elevated}>
+          <CardContent>
+            <div className="text-sm">{label}</div>
+          </CardContent>
+        </Card>
+      ))}
     </>
   ),
 };

--- a/packages/ui/src/components/atoms/primitives/Dialog.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Dialog.stories.tsx
@@ -7,26 +7,43 @@ import {
   DialogTrigger,
 } from "./dialog";
 
-const meta: Meta<typeof Dialog> = {
+const meta = {
+  title: "Primitives/Dialog",
   component: Dialog,
+  subcomponents: {
+    DialogTrigger,
+    DialogContent,
+    DialogTitle,
+    DialogDescription,
+  },
   args: {
     defaultOpen: true,
+    triggerLabel: "Open dialog",
+    title: "Schedule maintenance",
+    description: "Choose a window that works best for you.",
   },
   argTypes: {
     defaultOpen: { control: "boolean" },
+    triggerLabel: { control: "text" },
+    title: { control: "text" },
+    description: { control: "text" },
   },
-};
+} satisfies Meta<typeof Dialog>;
 export default meta;
 
-export const Default: StoryObj<typeof Dialog> = {
-  render: (args) => (
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: ({ triggerLabel, title, description, ...args }) => (
     <Dialog {...args}>
       <DialogTrigger asChild>
-        <button>Open</button>
+        <button type="button" className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-primary-foreground">
+          {triggerLabel}
+        </button>
       </DialogTrigger>
       <DialogContent>
-        <DialogTitle>Title</DialogTitle>
-        <DialogDescription>Description</DialogDescription>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
       </DialogContent>
     </Dialog>
   ),

--- a/packages/ui/src/components/atoms/primitives/Table.stories.tsx
+++ b/packages/ui/src/components/atoms/primitives/Table.stories.tsx
@@ -1,10 +1,60 @@
+import type { ReactNode } from "react";
 import { type Meta, type StoryObj } from "@storybook/react";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
 import { Stack } from "./Stack";
 
-const meta: Meta<typeof Table> = {
+type TableStoryArgs = React.ComponentProps<typeof Table> & {
+  columns: string[];
+  rows: { cells: ReactNode[]; state?: "selected" }[];
+  caption?: string;
+};
+
+const renderTable = ({ columns, rows, caption }: TableStoryArgs) => (
+  <Stack gap={3}>
+    <Table>
+      {caption ? (
+        <caption className="text-left text-sm text-muted-foreground">{caption}</caption>
+      ) : null}
+      <TableHeader>
+        <TableRow>
+          {columns.map((column) => (
+            <TableHead key={column}>{column}</TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map(({ cells, state }, index) => (
+          <TableRow key={cells.join("-") || index} data-state={state}>
+            {cells.map((cell, cellIndex) => (
+              <TableCell key={`${index}-${cellIndex}`}>{cell}</TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+    <p className="text-sm text-muted-foreground">
+      Hover rows to see surface-2; selected row uses surface-3.
+    </p>
+  </Stack>
+);
+
+const meta = {
   title: "Primitives/Table",
   component: Table,
+  subcomponents: {
+    TableHeader,
+    TableBody,
+    TableRow,
+    TableHead,
+    TableCell,
+  },
   decorators: [
     (Story) => (
       <div className="p-8">
@@ -12,35 +62,22 @@ const meta: Meta<typeof Table> = {
       </div>
     ),
   ],
-};
+} satisfies Meta<typeof Table>;
 export default meta;
 
-export const HoverVsSelected: StoryObj<typeof Table> = {
-  render: () => (
-    <Stack gap={3}>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Product</TableHead>
-            <TableHead>Price</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          <TableRow>
-            <TableCell>Widget A</TableCell>
-            <TableCell>$10</TableCell>
-          </TableRow>
-          <TableRow data-state="selected">
-            <TableCell>Widget B (selected)</TableCell>
-            <TableCell>$20</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Widget C</TableCell>
-            <TableCell>$30</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-      <p className="text-sm text-muted-foreground">Hover rows to see surface-2; selected row uses surface-3.</p>
-    </Stack>
-  ),
+type Story = StoryObj<typeof meta>;
+
+const hoverVsSelectedArgs: TableStoryArgs = {
+  columns: ["Product", "Price"],
+  rows: [
+    { cells: ["Widget A", "$10"] },
+    { cells: ["Widget B (selected)", "$20"], state: "selected" },
+    { cells: ["Widget C", "$30"] },
+  ],
+  caption: "Recent purchases",
+};
+
+export const HoverVsSelected: Story = {
+  args: hoverVsSelectedArgs,
+  render: (args) => renderTable(args as TableStoryArgs),
 };


### PR DESCRIPTION
## Summary
- declare subcomponents for Card, Dialog, and Table primitives to surface child props in docs
- restructure Dialog story around args-driven composition so controls can adjust child content
- refactor Table story to use reusable template data while documenting related child components

## Testing
- pnpm --filter @acme/ui lint *(fails: missing local @acme/eslint-plugin-ds package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfab32320832fad1542a4a02cddae