### PR TITLE
refactor: reuse component stories in AppShell

### DIFF
--- a/packages/ui/src/components/templates/AppShell.Matrix.stories.tsx
+++ b/packages/ui/src/components/templates/AppShell.Matrix.stories.tsx
@@ -1,68 +1,84 @@
 // packages/ui/components/templates/AppShell.Matrix.stories.tsx
 
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { makeStateStory } from "../../story-utils/createStories";
+import { AppShell } from "./AppShell";
+import { buildAppShellArgs } from "./AppShell.story-helpers";
+
+const componentDescription = `High-level application shell. Wraps header/side navigation/footer and content, providing Theme/Layout providers.
+
+Usage:
+
+\`\`\`tsx
 import { AppShell } from './AppShell';
-import type { Locale } from '@acme/i18n/locales';
 import { Header } from '../organisms/Header';
 import { SideNav } from '../organisms/SideNav';
 import { Footer } from '../organisms/Footer';
 import { Content } from '../organisms/Content';
-import { makeStateStory } from '../../story-utils/createStories';
 
-const meta: Meta<typeof AppShell> = {
-  title: 'Templates/AppShell/Matrix',
+<AppShell
+  header={<Header locale={"en" as any} shopName="Demo" nav={[]} />}
+  sideNav={<SideNav>Nav</SideNav>}
+  footer={<Footer shopName="Demo">Footer</Footer>}
+>
+  <Content>Content</Content>
+</AppShell>
+
+// Key args: header, sideNav, footer, children
+\`\`\``;
+
+const meta = {
+  title: "Templates/AppShell/Matrix",
   component: AppShell,
-  parameters: { docs: { autodocs: false } },
   parameters: {
     docs: {
+      autodocs: false,
       description: {
-        component: `High-level application shell. Wraps header/side navigation/footer and content, providing Theme/Layout providers.\n\nUsage:\n\n\`\`\`tsx\nimport { AppShell } from './AppShell';\nimport { Header } from '../organisms/Header';\nimport { SideNav } from '../organisms/SideNav';\nimport { Footer } from '../organisms/Footer';\nimport { Content } from '../organisms/Content';\n\n<AppShell\n  header={<Header locale={"en" as any} shopName="Demo" nav={[]} />}\n  sideNav={<SideNav>Nav</SideNav>}\n  footer={<Footer shopName="Demo">Footer</Footer>}\n>\n  <Content>Content</Content>\n</AppShell>\n\n// Key args: header, sideNav, footer, children\n\`\`\``,
+        component: componentDescription,
       },
     },
   },
-  args: {
-    header: <Header locale={"en" as Locale} shopName="Demo" nav={[]} />,
-    sideNav: <SideNav>Nav</SideNav>,
-    footer: <Footer shopName="Demo">Footer</Footer>,
-    children: <Content>Content</Content>,
-  },
-};
+  args: buildAppShellArgs(),
+} satisfies Meta<typeof AppShell>;
+
 export default meta;
 
-type Story = StoryObj<typeof AppShell>;
+type Story = StoryObj<typeof meta>;
+
 const baseArgs = meta.args!;
 
-export const Default: Story = makeStateStory(baseArgs, {}, 'default', {
+export const Default: Story = makeStateStory(baseArgs, {}, "default", {
   a11y: true,
-  viewports: ['desktop'],
-  tags: ['visual'],
-  docsDescription: 'Shell with header, side navigation and footer around page content.',
+  viewports: ["desktop"],
+  tags: ["visual"],
+  docsDescription: "Shell with header, side navigation and footer around page content.",
 });
 
-export const Loading: Story = makeStateStory(baseArgs, { sideNav: null }, 'loading', {
-  viewports: ['mobile1'],
-  tags: ['visual'],
-  docsDescription: 'Simulated loading: side navigation hidden to mimic minimal shell.',
+export const Loading: Story = makeStateStory(baseArgs, { sideNav: null }, "loading", {
+  viewports: ["mobile1"],
+  tags: ["visual"],
+  docsDescription: "Simulated loading: side navigation hidden to mimic minimal shell.",
 });
 
-export const Empty: Story = makeStateStory(baseArgs, { children: null }, 'empty', {
+export const Empty: Story = makeStateStory(baseArgs, { children: null }, "empty", {
   a11y: true,
-  viewports: ['mobile1'],
-  tags: ['visual'],
-  docsDescription: 'No children content; demonstrates shell-only state.',
+  viewports: ["mobile1"],
+  tags: ["visual"],
+  docsDescription: "No children content; demonstrates shell-only state.",
 });
 
-export const Error: Story = makeStateStory(baseArgs, {}, 'error', {
+export const Error: Story = makeStateStory(baseArgs, {}, "error", {
   a11y: true,
   critical: true,
-  viewports: ['desktop'],
-  tags: ['visual', 'ci'],
-  docsDescription: 'Matrix completeness state; no network behavior.',
+  viewports: ["desktop"],
+  tags: ["visual", "ci"],
+  docsDescription: "Matrix completeness state; no network behavior.",
 });
 
-export const RTL: Story = makeStateStory(baseArgs, {}, 'default', {
+export const RTL: Story = makeStateStory(baseArgs, {}, "default", {
   rtl: true,
-  viewports: ['mobile1'],
-  tags: ['visual'],
-  docsDescription: 'RTL sample for shell chrome and content region.',
+  viewports: ["mobile1"],
+  tags: ["visual"],
+  docsDescription: "RTL sample for shell chrome and content region.",
 });

--- a/packages/ui/src/components/templates/AppShell.stories.tsx
+++ b/packages/ui/src/components/templates/AppShell.stories.tsx
@@ -1,13 +1,13 @@
 // packages/ui/components/templates/AppShell.stories.tsx
 
 import type { Meta, StoryObj } from "@storybook/react";
-import { Content } from "../organisms/Content";
-import { Footer } from "../organisms/Footer";
-import { Header } from "../organisms/Header";
-import { SideNav } from "../organisms/SideNav";
-import { AppShell } from "./AppShell";
 
-const meta: Meta<typeof AppShell> = {
+import { AppShell } from "./AppShell";
+import { buildAppShellArgs } from "./AppShell.story-helpers";
+
+const baseArgs = buildAppShellArgs();
+
+const meta = {
   title: "Layout/AppShell",
   component: AppShell,
   tags: ["autodocs"],
@@ -19,32 +19,20 @@ const meta: Meta<typeof AppShell> = {
       },
     },
   },
-};
+  args: baseArgs,
+} satisfies Meta<typeof AppShell>;
+
 export default meta;
 
-export const Default: StoryObj<typeof AppShell> = {
-  render: () => (
-    <AppShell
-      header={<Header locale="en" shopName="Demo">Header</Header>}
-      sideNav={<SideNav>Nav</SideNav>}
-      footer={<Footer shopName="Demo">Footer</Footer>}
-    >
-      <Content>Content</Content>
-    </AppShell>
-  ),
-};
+type Story = StoryObj<typeof meta>;
 
-export const WithCustomBackground: StoryObj<typeof AppShell> = {
-  render: () => (
-    <AppShell
-      className="bg-bg"
-      header={<Header locale="en" shopName="Demo">Header</Header>}
-      sideNav={<SideNav>Nav</SideNav>}
-      footer={<Footer shopName="Demo">Footer</Footer>}
-    >
-      <Content>Content</Content>
-    </AppShell>
-  ),
+export const Default: Story = {};
+
+export const WithCustomBackground: Story = {
+  args: {
+    ...baseArgs,
+    className: "bg-bg",
+  },
   parameters: {
     docs: {
       description: {

--- a/packages/ui/src/components/templates/AppShell.story-helpers.tsx
+++ b/packages/ui/src/components/templates/AppShell.story-helpers.tsx
@@ -1,0 +1,52 @@
+import { Header, type HeaderProps } from "../organisms/Header";
+import * as HeaderStories from "../organisms/Header.stories";
+import { SideNav, type SideNavProps } from "../organisms/SideNav";
+import * as SideNavStories from "../../layout/SideNav.stories";
+import { Footer, type FooterProps } from "../organisms/Footer";
+import * as FooterStories from "../organisms/Footer.stories";
+import { Content, type ContentProps } from "../organisms/Content";
+import * as ContentStories from "../organisms/Content.stories";
+
+import type { AppShellProps } from "./AppShell";
+
+/**
+ * Builds a complete set of slot props for the {@link AppShell} template using
+ * the default stories from the slot components. Reusing story args keeps
+ * screen-level stories in sync with the underlying building blocks while
+ * avoiding duplicated fixture data.
+ */
+export function buildAppShellArgs(
+  overrides: Partial<AppShellProps> = {}
+): AppShellProps {
+  const headerProps: HeaderProps = {
+    locale: "en" as HeaderProps["locale"],
+    nav: [],
+    searchSuggestions: [],
+    shopName: "Demo Shop",
+    ...(HeaderStories.Default.args as HeaderProps | undefined),
+  };
+
+  const sideNavProps: SideNavProps = {
+    children: "Nav",
+    ...(SideNavStories.Default.args as SideNavProps | undefined),
+  };
+
+  const footerProps: FooterProps = {
+    children: "Footer",
+    shopName: "Demo Shop",
+    ...(FooterStories.Default.args as FooterProps | undefined),
+  };
+
+  const contentProps: ContentProps = {
+    children: "Content",
+    ...(ContentStories.Default.args as ContentProps | undefined),
+  };
+
+  return {
+    header: <Header {...headerProps} />,
+    sideNav: <SideNav {...sideNavProps} />,
+    footer: <Footer {...footerProps} />,
+    children: <Content {...contentProps} />,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- add a helper that composes AppShell slot content from existing component stories
- update the AppShell stories to rely on shared args instead of inline render functions
- ensure the matrix stories reuse the same composed data and consolidate docs parameters

## Testing
- pnpm --filter @acme/ui lint *(fails: missing @acme/eslint-plugin-ds build output in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfa994bd0832fb7b86db124c1f36f