### PR TITLE
test: expand organism coverage

### DIFF
--- a/packages/ui/src/components/organisms/__tests__/DataTable.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/DataTable.test.tsx
@@ -79,4 +79,35 @@ describe("DataTable", () => {
     await user.click(rowAlpha);
     expect(rowAlpha).not.toHaveAttribute("data-state");
   });
+
+  it("generates keys for rows without id or key fields", () => {
+    const setSpy = jest.spyOn(WeakMap.prototype, "set");
+    try {
+      render(
+        <DataTable
+          rows={[{ name: "Anon" }, { name: "Beta" }]}
+          columns={[{ header: "Name", render: (row: { name: string }) => row.name }]}
+        />
+      );
+      expect(setSpy).toHaveBeenCalled();
+    } finally {
+      setSpy.mockRestore();
+    }
+  });
+
+  it("stringifies primitive rows to derive keys", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      render(
+        <DataTable
+          rows={["One", "Two"]}
+          columns={[{ header: "Value", render: (value: string) => value }]}
+        />
+      );
+      expect(screen.getByText("One")).toBeInTheDocument();
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/packages/ui/src/components/organisms/__tests__/LiveChatWidget.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/LiveChatWidget.test.tsx
@@ -1,0 +1,46 @@
+/* i18n-exempt file -- tests rely on literal chat copy */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LiveChatWidget } from "../LiveChatWidget";
+
+describe("LiveChatWidget", () => {
+  it("sends messages, auto-replies, and resets the input", async () => {
+    const user = userEvent.setup();
+    render(<LiveChatWidget bottomOffset={24} width={360} />);
+
+    const trigger = screen.getByRole("button", { name: /live chat/i });
+    expect(trigger).toHaveStyle({ bottom: "24px" });
+
+    await user.click(trigger);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveStyle({ bottom: "24px" });
+
+    const input = await screen.findByPlaceholderText("Type a message…");
+
+    await user.type(input, "   ");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    expect(screen.queryByText("Thanks for your message!")).not.toBeInTheDocument();
+
+    await user.type(input, "Hello there");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(await screen.findByText("Hello there")).toBeInTheDocument();
+    expect(await screen.findByText("Thanks for your message!")).toBeInTheDocument();
+    expect(input).toHaveValue("");
+  });
+
+  it("applies Tailwind bottom offsets when provided as a class", async () => {
+    const user = userEvent.setup();
+    render(<LiveChatWidget bottomOffset="bottom-10" className="custom" />);
+
+    const trigger = screen.getByRole("button", { name: /live chat/i });
+    expect(trigger.className).toContain("bottom-10");
+    expect(trigger.className).toContain("custom");
+
+    await user.click(trigger);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.className).toContain("bottom-10");
+  });
+});

--- a/packages/ui/src/components/organisms/__tests__/MiniCart.client.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/MiniCart.client.test.tsx
@@ -25,7 +25,10 @@ describe("MiniCart client", () => {
   });
 
   it("renders subtotal and displays toast when dispatch errors occur", async () => {
-    const dispatch = jest.fn().mockRejectedValue(new Error("fail"));
+    const dispatch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce("nope");
     mockUseCart.mockReturnValue([
       {
         "sku1:m": {
@@ -57,6 +60,43 @@ describe("MiniCart client", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /remove/i }));
     expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku1:m" });
-    expect(await screen.findByText("fail")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Failed to update cart.")
+    ).toBeInTheDocument();
+  });
+
+  it("handles successful quantity updates and numeric drawer widths", async () => {
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    mockUseCart.mockReturnValue([
+      {
+        "sku2:l": {
+          sku: { id: "sku2", title: "Other", price: 15, sizes: [] },
+          qty: 2,
+          size: "L",
+        },
+      },
+      dispatch,
+    ]);
+
+    render(<MiniCart trigger={<button>Cart</button>} width={320} />);
+    await userEvent.click(screen.getByText("Cart"));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveStyle({ width: "320px" });
+    expect(screen.getByText("Other")).toBeInTheDocument();
+    expect(screen.getByText("(L)")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /decrease quantity/i })
+    );
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "setQty",
+      id: "sku2:l",
+      qty: 1,
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /remove/i }));
+    expect(dispatch).toHaveBeenCalledWith({ type: "remove", id: "sku2:l" });
+    expect(screen.queryByText("Failed to update cart.")).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx
+++ b/packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx
@@ -1,5 +1,6 @@
 /* i18n-exempt file -- tests use literal product titles and labels */
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, screen, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { RecommendationCarousel } from "../RecommendationCarousel";
 import type { SKU } from "@acme/types";
 
@@ -48,6 +49,10 @@ describe("RecommendationCarousel responsive counts", () => {
       }) as unknown as typeof fetch;
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   function setWidth(width: number) {
     Object.defineProperty(window, "innerWidth", { value: width, configurable: true });
   }
@@ -68,5 +73,208 @@ describe("RecommendationCarousel responsive counts", () => {
     );
     const slide = container.querySelector(".snap-start") as HTMLElement;
     expect(slide.style.flex).toBe("0 0 25%");
+  });
+
+  it("supports manual navigation via controls and keyboard", async () => {
+    jest.useFakeTimers();
+    Object.defineProperty(window, "innerWidth", {
+      value: 1280,
+      configurable: true,
+    });
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    const { container } = render(
+      <RecommendationCarousel
+        products={[...products, { ...products[0], id: "3" }]}
+        showArrows
+        showDots
+        loop={false}
+        minItems={1}
+        maxItems={1}
+      />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".snap-x")).toBeTruthy()
+    );
+    const scroller = container.querySelector(".snap-x") as HTMLDivElement;
+    Object.defineProperty(scroller, "clientWidth", {
+      value: 200,
+      configurable: true,
+    });
+    const scrollTo = jest.fn();
+    scroller.scrollTo = scrollTo;
+
+    const prev = screen.getByRole("button", { name: /previous/i });
+    const next = screen.getByRole("button", { name: /next/i });
+    expect(prev).toBeDisabled();
+    expect(next).toBeEnabled();
+
+    await user.click(next);
+    await waitFor(() => expect(scrollTo).toHaveBeenLastCalledWith({
+      behavior: "smooth",
+      left: 200,
+    }));
+
+    expect(prev).toBeEnabled();
+
+    const dots = screen.getAllByRole("button", { name: /go to page/i });
+    await waitFor(() => expect(dots[1].className).toContain("bg-primary"));
+
+    await user.click(prev);
+    await waitFor(() => expect(scrollTo).toHaveBeenLastCalledWith({
+      behavior: "smooth",
+      left: 0,
+    }));
+
+    const region = screen.getByRole("region", { name: /recommended products/i });
+    region.focus();
+    await user.keyboard("{ArrowRight}");
+    await waitFor(() => expect(scrollTo).toHaveBeenLastCalledWith({
+      behavior: "smooth",
+      left: 200,
+    }));
+
+    await user.click(dots[0]);
+    await waitFor(() => expect(scrollTo).toHaveBeenLastCalledWith({
+      behavior: "smooth",
+      left: 0,
+    }));
+
+    jest.useRealTimers();
+  });
+
+  it("supports swipe gestures to change pages", async () => {
+    jest.useFakeTimers();
+    const { container } = render(
+      <RecommendationCarousel
+        products={[...products, { ...products[0], id: "3" }]}
+        showArrows
+        showDots
+        loop={false}
+        minItems={1}
+        maxItems={1}
+      />
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".snap-x")).toBeTruthy()
+    );
+    const scroller = container.querySelector(".snap-x") as HTMLDivElement;
+    Object.defineProperty(scroller, "clientWidth", {
+      value: 200,
+      configurable: true,
+    });
+    const scrollTo = jest.fn();
+    scroller.scrollTo = scrollTo;
+
+    fireEvent.touchStart(scroller, {
+      touches: [{ clientX: 200, clientY: 0 }],
+    } as unknown as TouchEvent);
+    fireEvent.touchMove(scroller, {
+      touches: [{ clientX: 80, clientY: 0 }],
+    } as unknown as TouchEvent);
+    fireEvent.touchEnd(scroller);
+
+    await waitFor(() => expect(scrollTo).toHaveBeenLastCalledWith({
+      behavior: "smooth",
+      left: 200,
+    }));
+
+    fireEvent.touchStart(scroller, {
+      touches: [{ clientX: 200, clientY: 0 }],
+    } as unknown as TouchEvent);
+    fireEvent.touchMove(scroller, {
+      touches: [{ clientX: 180, clientY: 0 }],
+    } as unknown as TouchEvent);
+    fireEvent.touchEnd(scroller);
+
+    await waitFor(() => expect(scrollTo).toHaveBeenLastCalledWith({
+      behavior: "smooth",
+      left: 200,
+    }));
+  });
+
+  it("autoplays through pages and stops when looping is disabled", async () => {
+    jest.useFakeTimers();
+    const { container } = render(
+      <RecommendationCarousel
+        products={[...products]}
+        showDots
+        loop={false}
+        minItems={1}
+        maxItems={1}
+      />
+    );
+
+    const scroller = await waitFor(() => {
+      const node = container.querySelector(".snap-x") as HTMLDivElement | null;
+      expect(node).toBeTruthy();
+      return node!;
+    });
+    Object.defineProperty(scroller, "clientWidth", {
+      value: 200,
+      configurable: true,
+    });
+    const scrollTo = jest.fn();
+    scroller.scrollTo = scrollTo;
+
+    await waitFor(() => expect(jest.getTimerCount()).toBeGreaterThan(0));
+    jest.advanceTimersByTime(3000);
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledTimes(1));
+    expect(scrollTo).toHaveBeenLastCalledWith({ behavior: "smooth", left: 200 });
+
+    jest.advanceTimersByTime(3000);
+    expect(scrollTo).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("syncs the active page with scroll position", async () => {
+    const { container } = render(
+      <RecommendationCarousel
+        products={[...products, { ...products[0], id: "3" }]}
+        showDots
+        minItems={1}
+        maxItems={1}
+      />
+    );
+
+    const scroller = await waitFor(() => {
+      const node = container.querySelector(".snap-x") as HTMLDivElement | null;
+      expect(node).toBeTruthy();
+      return node!;
+    });
+    Object.defineProperty(scroller, "clientWidth", {
+      value: 200,
+      configurable: true,
+    });
+    const dots = screen.getAllByRole("button", { name: /go to page/i });
+
+    Object.defineProperty(scroller, "scrollLeft", {
+      value: 200,
+      configurable: true,
+    });
+    await act(async () => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    await waitFor(() => expect(dots[1].className).toContain("bg-primary"));
+  });
+
+  it("renders an error state when fetching recommendations fails", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    global.fetch = jest.fn().mockRejectedValue(new Error("nope"));
+    const ErrorState = () => <div role="status">failed</div>;
+
+    render(
+      <RecommendationCarousel
+        endpoint="/api"
+        ErrorState={ErrorState}
+      />
+    );
+
+    expect(await screen.findByRole("status")).toHaveTextContent("failed");
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- extend RecommendationCarousel interaction coverage including keyboard, swipe, autoplay, scroll sync, and error handling tests
- add MiniCart happy-path assertions plus translation fallback verification
- cover LiveChatWidget messaging and layout offsets along with DataTable key-generation edge cases

## Testing
- `pnpm --filter @acme/ui test -- --runTestsByPath packages/ui/src/components/organisms/__tests__/RecommendationCarousel.test.tsx packages/ui/src/components/organisms/__tests__/MiniCart.client.test.tsx packages/ui/src/components/organisms/__tests__/LiveChatWidget.test.tsx packages/ui/src/components/organisms/__tests__/DataTable.test.tsx` *(fails: repository-wide coverage threshold enforced by script)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf8d1a97c832f89ed676f395c5ce8