### PR TITLE
Add portable story diagnostics coverage

### DIFF
--- a/apps/storybook/.storybook/stories/ErrorScenarios.stories.tsx
+++ b/apps/storybook/.storybook/stories/ErrorScenarios.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+interface ErrorButtonProps {
+  readonly label: string;
+  readonly triggerError?: boolean;
+}
+
+function ErrorButton({ label, triggerError = false }: ErrorButtonProps) {
+  if (triggerError) {
+    throw new Error("Portable stories usage guard triggered");
+  }
+
+  return (
+    <button type="button" data-testid="error-button">
+      {label}
+    </button>
+  );
+}
+
+const meta: Meta<typeof ErrorButton> = {
+  title: "Diagnostics/ErrorButton",
+  component: ErrorButton,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Utility stories that exercise error boundaries for portable-story tests.",
+      },
+    },
+  },
+  args: {
+    label: "Trigger",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ErrorButton>;
+
+export const SafeUsage: Story = {};
+
+export const ThrowsUsageError: Story = {
+  args: {
+    triggerError: true,
+  },
+  tags: ["!dev", "!test"],
+};

--- a/test/unit/storybook/__tests__/portable-stories.test.tsx
+++ b/test/unit/storybook/__tests__/portable-stories.test.tsx
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "@jest/globals";
+import { render } from "@testing-library/react";
+import { composeStories } from "@storybook/react";
+
+import * as errorStories from "../../../../apps/storybook/.storybook/stories/ErrorScenarios.stories";
+
+const { SafeUsage, ThrowsUsageError } = composeStories(errorStories);
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("portable Storybook stories", () => {
+  it("can render a safe story without depending on Storybook runtime", () => {
+    const { container } = render(<SafeUsage />);
+
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <button
+        data-testid="error-button"
+        type="button"
+      >
+        Trigger
+      </button>
+    `);
+  });
+
+  it("surfaces intentional usage errors for diagnostic stories", () => {
+    expect(() => render(<ThrowsUsageError />)).toThrow(
+      "Portable stories usage guard triggered",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a hidden diagnostic ErrorButton story that exposes a controlled error state for portable-story tests
- add a focused Jest suite that reuses the portable story to snapshot the safe markup and assert the intentional error path

## Testing
- CI=1 pnpm exec jest test/unit/storybook/__tests__/portable-stories.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dbfb3ae590832f85b081c78cbad6e8