### PR TITLE
Use MSW to mock Storybook network requests

### DIFF
--- a/packages/ui/src/components/cms/ShopSelector.stories.tsx
+++ b/packages/ui/src/components/cms/ShopSelector.stories.tsx
@@ -1,11 +1,37 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { http, HttpResponse, delay } from "msw";
 import ShopSelector from "./ShopSelector";
+
+const baseShops = ["acme-boutique", "luxury-lab", "flagship-eu"];
 
 const meta: Meta<typeof ShopSelector> = {
   title: "CMS/ShopSelector",
   component: ShopSelector,
   tags: ["autodocs"],
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/shops", async () => {
+          await delay(120);
+          return HttpResponse.json(baseShops, { status: 200 });
+        }),
+      ],
+    },
+  },
 };
 export default meta;
 
 export const Default: StoryObj<typeof ShopSelector> = {};
+
+export const ErrorState: StoryObj<typeof ShopSelector> = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/shops", async () => {
+          await delay(120);
+          return HttpResponse.json({ error: "mock-error" }, { status: 500 });
+        }),
+      ],
+    },
+  },
+};

--- a/packages/ui/src/components/cms/page-builder/ThemePanel.stories.tsx
+++ b/packages/ui/src/components/cms/page-builder/ThemePanel.stories.tsx
@@ -1,8 +1,14 @@
 // packages/ui/src/components/cms/page-builder/ThemePanel.stories.tsx
 import type { Meta, StoryObj } from "@storybook/react";
-import React, { useEffect } from "react";
+import React from "react";
+import { http, HttpResponse } from "msw";
 import ThemePanel from "./ThemePanel";
 import { Dialog } from "../../atoms/shadcn";
+
+const themeResponse = {
+  themeDefaults: { "color.brand": "#111827", "font.body": "Inter" },
+  themeTokens: { "color.brand": "#111827", "font.body": "Inter" },
+};
 
 const meta: Meta<typeof ThemePanel> = {
   title: "CMS/Page Builder/ThemePanel",
@@ -14,48 +20,26 @@ const meta: Meta<typeof ThemePanel> = {
         component: "Panel to preview and edit theme tokens pulled from the CMS; story stubs backend responses.",
       },
     },
+    msw: {
+      handlers: [
+        http.get(/\/cms\/api\/shops\/.+\/theme$/, () => HttpResponse.json(themeResponse)),
+        http.patch(/\/cms\/api\/shops\/.+\/theme$/, async ({ request }) => {
+          // Echo persisted payload to help with interaction debugging
+          const body = await request.json().catch(() => ({}));
+          return HttpResponse.json({ ok: true, body });
+        }),
+      ],
+    },
   },
 };
 export default meta;
 
 type Story = StoryObj<typeof ThemePanel>;
 
-function StoryWithFetchStub() {
-  // Provide a lightweight fetch stub to return example theme data
-  useEffect(() => {
-    const orig = globalThis.fetch;
-    globalThis.fetch = async (
-      input: RequestInfo | URL,
-      init?: RequestInit
-    ): Promise<Response> => {
-      const u = String(input);
-      if (u.includes("/cms/api/shops/") && u.endsWith("/theme")) {
-        const doc = document.documentElement;
-        const brand = getComputedStyle(doc)
-          .getPropertyValue("--color-brand")
-          .trim();
-        return new Response(
-          JSON.stringify({
-            themeDefaults: { "color.brand": brand || "", "font.body": "Inter" },
-            themeTokens: { "color.brand": brand || "", "font.body": "Inter" },
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
-      }
-      return orig(input, init);
-    };
-    return () => {
-      globalThis.fetch = orig;
-    };
-  }, []);
-
-  return (
+export const Basic: Story = {
+  render: () => (
     <Dialog open>
       <ThemePanel />
     </Dialog>
-  );
-}
-
-export const Basic: Story = {
-  render: () => <StoryWithFetchStub />,
+  ),
 };


### PR DESCRIPTION
## Summary
- add MSW-backed handlers to the ShopSelector story and document an error scenario
- replace manual fetch overrides in UploadPanel and LinkPicker stories with MSW handlers
- configure the ThemePanel story to use MSW for its theme read/write calls

## Testing
- pnpm --filter @acme/ui lint *(fails: missing @acme/eslint-plugin-ds build output in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfcc62930832fb04cc453af030e4a