### PR TITLE
Align Storybook background defaults with globals API

### DIFF
--- a/apps/storybook/.storybook-ci/preview.tsx
+++ b/apps/storybook/.storybook-ci/preview.tsx
@@ -36,7 +36,6 @@ const preview: Preview = {
   parameters: {
     ...a11yParameters,
     backgrounds: {
-      default: DEFAULT_BACKGROUND,
       options: backgroundOptions,
     },
     // CI runs on a curated, fast subset. A11y is enabled per critical story via story parameters.
@@ -48,6 +47,9 @@ const preview: Preview = {
     }),
     withTokens,
   ],
+  initialGlobals: {
+    backgrounds: { value: DEFAULT_BACKGROUND },
+  },
   globals: {
     ...a11yGlobals,
   },

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -352,12 +352,14 @@ const preview: Preview = {
       defaultViewport: "desktop",
     },
     backgrounds: {
-      default: DEFAULT_BACKGROUND,
       options: backgroundOptions,
     },
   },
   globals: {
     ...a11yGlobals,
+  },
+  initialGlobals: {
+    backgrounds: { value: DEFAULT_BACKGROUND },
   },
   decorators: [
     (Story) => (


### PR DESCRIPTION
## Summary
- update Storybook preview configs to rely on the shared background options map
- set the default background through Storybook `initialGlobals` in both app and CI previews

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dbfefad8ac832fa61f468762e995de