### PR TITLE
feat(storybook): add highlight decorator support

### DIFF
--- a/apps/storybook/.storybook-ci/preview.tsx
+++ b/apps/storybook/.storybook-ci/preview.tsx
@@ -4,6 +4,7 @@ import "../../../packages/themes/base/src/tokens.css";
 import en from "../../../packages/i18n/src/en.json";
 import { createBackgroundOptions, DEFAULT_BACKGROUND } from "../.storybook/backgrounds";
 import { a11yGlobals, a11yParameters } from "../.storybook/a11y";
+import { withHighlight } from "../.storybook/decorators/highlightDecorator";
 
 const t = (key: string) => (en as Record<string, string>)[key] ?? key;
 
@@ -47,6 +48,7 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
     withTokens,
+    withHighlight,
   ],
   globals: {
     ...a11yGlobals,

--- a/apps/storybook/.storybook/decorators/highlightDecorator.tsx
+++ b/apps/storybook/.storybook/decorators/highlightDecorator.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useMemo } from "react";
+import type { Decorator } from "@storybook/react";
+import { useChannel } from "storybook/preview-api";
+import {
+  HIGHLIGHT,
+  REMOVE_HIGHLIGHT,
+  RESET_HIGHLIGHT,
+  type HighlightOptions,
+} from "storybook/highlight";
+import type { StoryHighlightParameter } from "../types";
+
+const normalizeHighlightParameter = (
+  parameter: StoryHighlightParameter | undefined,
+): { options: HighlightOptions; resetOnStoryChange: boolean } | null => {
+  if (!parameter || parameter === false) {
+    return null;
+  }
+
+  if (Array.isArray(parameter)) {
+    return parameter.length > 0
+      ? { options: { selectors: parameter }, resetOnStoryChange: true }
+      : null;
+  }
+
+  if (parameter.disable) {
+    return null;
+  }
+
+  const { resetOnStoryChange = true, disable: _disable, ...options } = parameter;
+  if (!options.selectors || options.selectors.length === 0) {
+    return null;
+  }
+
+  return { options: options as HighlightOptions, resetOnStoryChange };
+};
+
+export const withHighlight: Decorator = (Story, context) => {
+  const highlightParameter = context.parameters.highlight as
+    | StoryHighlightParameter
+    | undefined;
+
+  const highlightConfig = useMemo(() => {
+    if (context.viewMode !== "story") {
+      return null;
+    }
+
+    return normalizeHighlightParameter(highlightParameter);
+  }, [context.viewMode, highlightParameter]);
+
+  const emit = useChannel({}, []);
+
+  useEffect(() => {
+    if (!highlightConfig) {
+      return;
+    }
+
+    const { options, resetOnStoryChange } = highlightConfig;
+    emit(HIGHLIGHT, options);
+
+    return () => {
+      if (options.id) {
+        emit(REMOVE_HIGHLIGHT, options.id);
+        return;
+      }
+
+      if (resetOnStoryChange) {
+        emit(RESET_HIGHLIGHT);
+      }
+    };
+  }, [emit, highlightConfig]);
+
+  return <Story />;
+};

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -23,6 +23,7 @@ import { mapDataStateToMsw } from "./msw/state-mapping";
 import { VIEWPORTS } from "./viewports";
 import { withRTL } from "./decorators/rtlDecorator";
 import { withPerf } from "./decorators/perfDecorator";
+import { withHighlight } from "./decorators/highlightDecorator";
 import { a11yGlobals, a11yParameters } from "./a11y";
 import { createBackgroundOptions, DEFAULT_BACKGROUND } from "./backgrounds";
 import type { ToolbarGlobals, StoryDataState } from "./types";
@@ -377,6 +378,7 @@ const preview: Preview = {
     }),
     withRTL,
     withGlobals,
+    withHighlight,
     withPerf,
     withProviders,
   ],

--- a/apps/storybook/.storybook/types.ts
+++ b/apps/storybook/.storybook/types.ts
@@ -22,3 +22,17 @@ declare global {
   }
 }
 
+export type StoryHighlightParameter =
+  | false
+  | string[]
+  | ({
+      disable?: boolean;
+      resetOnStoryChange?: boolean;
+    } & import("storybook/highlight").HighlightOptions);
+
+declare module "@storybook/types" {
+  interface Parameters {
+    highlight?: StoryHighlightParameter;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable highlight decorator that normalizes story parameters and emits Storybook highlight events
- register the decorator across the primary and CI preview configs and declare a typed `parameters.highlight`

## Testing
- pnpm --filter @apps/storybook lint

------
https://chatgpt.com/codex/tasks/task_e_68dbff2862fc832fa0801395e7cae796