### PR TITLE
Enable Storybook measure and outline tooling

### DIFF
--- a/apps/storybook/.storybook-ci/main.ts
+++ b/apps/storybook/.storybook-ci/main.ts
@@ -28,6 +28,8 @@ const config: StorybookConfig = {
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-a11y",
+    "@storybook/addon-measure",
+    "@storybook/addon-outline",
     "@chromatic-com/storybook",
     "@storybook/addon-themes",
     "@storybook/addon-viewport",

--- a/apps/storybook/.storybook-ci/preview.tsx
+++ b/apps/storybook/.storybook-ci/preview.tsx
@@ -39,6 +39,12 @@ const preview: Preview = {
       default: DEFAULT_BACKGROUND,
       options: backgroundOptions,
     },
+    measure: {
+      disable: false,
+    },
+    outline: {
+      disable: false,
+    },
     // CI runs on a curated, fast subset. A11y is enabled per critical story via story parameters.
   },
   decorators: [

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -35,6 +35,8 @@ const config: StorybookConfig = {
     // Essentials are largely built-in on SB9; keep only specific addons we use
     "@storybook/addon-a11y", // i18n-exempt -- ABC-123 [ttl=2025-12-31]
     "@storybook/addon-docs", // i18n-exempt -- ABC-123 [ttl=2025-12-31]
+    "@storybook/addon-measure", // i18n-exempt -- ABC-123 [ttl=2025-12-31]
+    "@storybook/addon-outline", // i18n-exempt -- ABC-123 [ttl=2025-12-31]
     "@chromatic-com/storybook", // i18n-exempt -- ABC-123 [ttl=2025-12-31]
     // interactions addon is pinned to SB8 and incompatible with SB9
     "@storybook/addon-themes", // i18n-exempt -- ABC-123 [ttl=2025-12-31]

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -324,6 +324,12 @@ const preview: Preview = {
       // Work around theming context conflicts by rendering plain code/pre elements
       components: docsComponents,
     },
+    measure: {
+      disable: false,
+    },
+    outline: {
+      disable: false,
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,


### PR DESCRIPTION
## Summary
- add the measure and outline addons to the main and CI Storybook configurations
- configure both Storybook preview setups to leave the measure and outline tools enabled by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbff3876e8832fa75145f19038a45b