### PR TITLE
feat(storybook): align viewport globals across previews

### DIFF
--- a/apps/storybook/.storybook-ci/preview.tsx
+++ b/apps/storybook/.storybook-ci/preview.tsx
@@ -4,6 +4,7 @@ import type { GlobalTypes } from "@storybook/types";
 import "../../../packages/themes/base/src/tokens.css";
 import en from "../../../packages/i18n/src/en.json";
 import { createBackgroundOptions, DEFAULT_BACKGROUND } from "../.storybook/backgrounds";
+import { VIEWPORTS } from "../.storybook/viewports";
 import { a11yGlobals, a11yParameters } from "../.storybook/a11y";
 import { withHighlight } from "../.storybook/decorators/highlightDecorator";
 
@@ -38,6 +39,8 @@ const preview: Preview = {
   globalTypes: toolbarGlobalTypes,
   initialGlobals: {
     tokens: "base",
+    backgrounds: { value: DEFAULT_BACKGROUND },
+    viewport: { value: "desktop", isRotated: false },
   },
   parameters: {
     ...a11yParameters,
@@ -50,6 +53,9 @@ const preview: Preview = {
     outline: {
       disable: false,
     },
+    viewport: {
+      options: VIEWPORTS,
+    },
     // CI runs on a curated, fast subset. A11y is enabled per critical story via story parameters.
   },
   decorators: [
@@ -60,9 +66,6 @@ const preview: Preview = {
     withTokens,
     withHighlight,
   ],
-  initialGlobals: {
-    backgrounds: { value: DEFAULT_BACKGROUND },
-  },
   globals: {
     ...a11yGlobals,
   },

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -329,6 +329,8 @@ const preview: Preview = {
     currency: "USD",
     net: "normal",
     netError: "off",
+    backgrounds: { value: DEFAULT_BACKGROUND },
+    viewport: { value: "desktop", isRotated: false },
   },
   loaders: [mswLoader],
   parameters: {
@@ -371,8 +373,7 @@ const preview: Preview = {
       },
     },
     viewport: {
-      viewports: VIEWPORTS,
-      defaultViewport: "desktop",
+      options: VIEWPORTS,
     },
     backgrounds: {
       options: backgroundOptions,
@@ -380,9 +381,6 @@ const preview: Preview = {
   },
   globals: {
     ...a11yGlobals,
-  },
-  initialGlobals: {
-    backgrounds: { value: DEFAULT_BACKGROUND },
   },
   decorators: [
     (Story) => (

--- a/apps/storybook/.storybook/viewports.ts
+++ b/apps/storybook/.storybook/viewports.ts
@@ -1,8 +1,34 @@
-type Viewport = { name: string; styles: { width: string; height: string } };
+type Viewport = {
+  name: string;
+  styles: { width: string; height: string };
+  type: 'desktop' | 'mobile' | 'tablet' | 'other';
+};
+
 export type ViewportMap = Record<string, Viewport>;
 
 export const VIEWPORTS: ViewportMap = {
-  mobile1: { name: 'Mobile • 360×640', styles: { width: '360px', height: '640px' } },
-  tablet: { name: 'Tablet • 768×1024', styles: { width: '768px', height: '1024px' } },
-  desktop: { name: 'Desktop • 1280×800', styles: { width: '1280px', height: '800px' } },
+  mobile1: {
+    // i18n-exempt -- ABC-123 [ttl=2025-12-31]
+    name: 'Mobile • 360×640',
+    styles: { width: '360px', height: '640px' },
+    type: 'mobile',
+  },
+  mobile2: {
+    // i18n-exempt -- ABC-123 [ttl=2025-12-31]
+    name: 'Mobile Large • 414×896',
+    styles: { width: '414px', height: '896px' },
+    type: 'mobile',
+  },
+  tablet: {
+    // i18n-exempt -- ABC-123 [ttl=2025-12-31]
+    name: 'Tablet • 768×1024',
+    styles: { width: '768px', height: '1024px' },
+    type: 'tablet',
+  },
+  desktop: {
+    // i18n-exempt -- ABC-123 [ttl=2025-12-31]
+    name: 'Desktop • 1280×800',
+    styles: { width: '1280px', height: '800px' },
+    type: 'desktop',
+  },
 };


### PR DESCRIPTION
## Summary
- update Storybook preview configs to use the viewport `options` API and declare defaults via `initialGlobals`
- extend the shared viewport preset with a large mobile size and annotate names with existing i18n exemptions
- wire the CI preview into the shared viewport settings for consistent responsive testing

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc01c2ff50832f9852d95c034c5a08