### PR TITLE
test: cover try-on hooks

### DIFF
--- a/packages/ui/src/hooks/tryon/__tests__/resize.test.ts
+++ b/packages/ui/src/hooks/tryon/__tests__/resize.test.ts
@@ -1,0 +1,105 @@
+import { resizeImageToMaxPx } from "../resize";
+
+describe("resizeImageToMaxPx", () => {
+  const originalCreateImageBitmap = global.createImageBitmap;
+  let originalCreateElement: typeof document.createElement;
+
+  beforeEach(() => {
+    originalCreateElement = document.createElement;
+  });
+
+  afterEach(() => {
+    (global as any).createImageBitmap = originalCreateImageBitmap;
+    document.createElement = originalCreateElement;
+    jest.restoreAllMocks();
+  });
+
+  function setupCanvas(overrides: Partial<HTMLCanvasElement> = {}) {
+    const ctx = { drawImage: jest.fn() } as unknown as CanvasRenderingContext2D;
+    const canvas: Partial<HTMLCanvasElement> = {
+      width: 0,
+      height: 0,
+      getContext: jest.fn().mockReturnValue(ctx),
+      toBlob: jest.fn((cb: BlobCallback) => cb(new Blob(["x"], { type: "image/png" }))),
+      ...overrides,
+    };
+    jest.spyOn(document, "createElement").mockReturnValue(canvas as HTMLCanvasElement);
+    return { canvas, ctx };
+  }
+
+  it("returns original dimensions when within bounds", async () => {
+    const bitmap = { width: 800, height: 600 };
+    (global as any).createImageBitmap = jest.fn().mockResolvedValue(bitmap);
+    const { canvas, ctx } = setupCanvas();
+    const file = new File(["data"], "photo.png", { type: "image/png" });
+
+    const result = await resizeImageToMaxPx(file, 1600);
+
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(600);
+    expect(result.blob.type).toBe("image/png");
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(600);
+    expect(ctx.drawImage).toHaveBeenCalledWith(bitmap, 0, 0, 800, 600);
+  });
+
+  it("scales down wide images to the max width", async () => {
+    const bitmap = { width: 2000, height: 1000 };
+    (global as any).createImageBitmap = jest.fn().mockResolvedValue(bitmap);
+    const { canvas } = setupCanvas();
+    const file = new File(["data"], "wide.jpg", { type: "image/jpeg" });
+
+    const result = await resizeImageToMaxPx(file, 1600);
+
+    expect(result.width).toBe(1600);
+    expect(result.height).toBe(800);
+    expect(canvas.width).toBe(1600);
+    expect(canvas.height).toBe(800);
+  });
+
+  it("scales down tall images to the max height", async () => {
+    const bitmap = { width: 1000, height: 2000 };
+    (global as any).createImageBitmap = jest.fn().mockResolvedValue(bitmap);
+    const { canvas } = setupCanvas();
+    const file = new File(["data"], "tall.webp", { type: "image/webp" });
+
+    const result = await resizeImageToMaxPx(file, 1600);
+
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(1600);
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(1600);
+  });
+
+  it("throws when the canvas context cannot be created", async () => {
+    const bitmap = { width: 500, height: 400 };
+    (global as any).createImageBitmap = jest.fn().mockResolvedValue(bitmap);
+    jest
+      .spyOn(document, "createElement")
+      .mockReturnValue({
+        width: 0,
+        height: 0,
+        getContext: () => null,
+        toBlob: jest.fn(),
+      } as unknown as HTMLCanvasElement);
+    const file = new File(["data"], "broken.png", { type: "image/png" });
+
+    await expect(resizeImageToMaxPx(file)).rejects.toThrow("Canvas 2D not supported");
+  });
+
+  it("rejects when encoding fails", async () => {
+    const bitmap = { width: 400, height: 400 };
+    (global as any).createImageBitmap = jest.fn().mockResolvedValue(bitmap);
+    jest
+      .spyOn(document, "createElement")
+      .mockReturnValue({
+        width: 0,
+        height: 0,
+        getContext: () => ({ drawImage: jest.fn() }),
+        toBlob: (cb: BlobCallback) => cb(null),
+      } as unknown as HTMLCanvasElement);
+    const file = new File(["data"], "fail.png", { type: "image/png" });
+
+    await expect(resizeImageToMaxPx(file)).rejects.toThrow("Failed to encode image");
+  });
+});

--- a/packages/ui/src/hooks/tryon/__tests__/state.test.tsx
+++ b/packages/ui/src/hooks/tryon/__tests__/state.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from "@testing-library/react";
+import { tryOnReducer, useTryOnDerived, type TryOnState } from "../state";
+
+describe("tryOnReducer", () => {
+  const base: TryOnState = { phase: "idle" };
+
+  it("resets to idle", () => {
+    expect(tryOnReducer({ ...base, phase: "failed" }, { type: "RESET" })).toEqual({ phase: "idle" });
+  });
+
+  it("stores upload details", () => {
+    const state = tryOnReducer(base, { type: "UPLOAD_START", jobId: "job", productId: "prod", mode: "garment" });
+    expect(state).toEqual({ phase: "uploading", jobId: "job", productId: "prod", mode: "garment" });
+  });
+
+  it("marks upload as done", () => {
+    const uploading = { phase: "uploading", jobId: "job" } as TryOnState;
+    const state = tryOnReducer(uploading, { type: "UPLOAD_DONE", sourceImageUrl: "src" });
+    expect(state).toEqual({ ...uploading, phase: "preprocessed", sourceImageUrl: "src" });
+  });
+
+  it("applies preprocess results", () => {
+    const preprocessed = tryOnReducer(
+      { phase: "preprocessed", sourceImageUrl: "src" },
+      { type: "PREPROCESS_DONE", maskUrl: "mask", depthUrl: "depth", poseUrl: "pose" }
+    );
+    expect(preprocessed).toEqual({ phase: "preview", sourceImageUrl: "src", maskUrl: "mask", depthUrl: "depth", poseUrl: "pose" });
+  });
+
+  it("keeps preview state when already ready", () => {
+    const preview = tryOnReducer({ phase: "preprocessed" }, { type: "PREVIEW_READY" });
+    expect(preview.phase).toBe("preview");
+  });
+
+  it("tracks enhance progress and completion", () => {
+    const enhancing = tryOnReducer({ phase: "preview" }, { type: "ENHANCE_START" });
+    expect(enhancing).toEqual({ phase: "enhancing", progress: 0 });
+    const progress = tryOnReducer(enhancing, { type: "ENHANCE_PROGRESS", progress: 0.5 });
+    expect(progress).toEqual({ phase: "enhancing", progress: 0.5 });
+    const done = tryOnReducer(progress, { type: "ENHANCE_DONE", resultUrl: "result" });
+    expect(done).toEqual({ phase: "done", progress: 1, resultUrl: "result" });
+  });
+
+  it("records failures", () => {
+    const failed = tryOnReducer({ phase: "enhancing" }, { type: "FAIL", message: "nope" });
+    expect(failed).toEqual({ phase: "failed", error: "nope" });
+  });
+
+  it("returns the same state for unknown actions", () => {
+    const state = { phase: "preview" } as TryOnState;
+    expect(tryOnReducer(state, { type: "UNKNOWN" } as any)).toBe(state);
+  });
+});
+
+describe("useTryOnDerived", () => {
+  it("computes derived flags and mirrors errors", () => {
+    const state: TryOnState = { phase: "enhancing", progress: 0.4, error: "boom" };
+    const { result, rerender } = renderHook(({ value }) => useTryOnDerived(value), { initialProps: { value: state } });
+    expect(result.current).toEqual({ canEnhance: false, canAdjust: true, error: "boom", progress: 0.4 });
+
+    rerender({ value: { phase: "preview", error: undefined, progress: undefined } });
+    expect(result.current).toEqual({ canEnhance: true, canAdjust: true, error: undefined, progress: null });
+  });
+});

--- a/packages/ui/src/hooks/tryon/__tests__/useDirectR2Upload.test.tsx
+++ b/packages/ui/src/hooks/tryon/__tests__/useDirectR2Upload.test.tsx
@@ -1,0 +1,313 @@
+import { act, renderHook } from "@testing-library/react";
+import { useDirectR2Upload } from "../useDirectR2Upload";
+import { resizeImageToMaxPx } from "../resize";
+
+jest.mock("../resize", () => ({
+  resizeImageToMaxPx: jest.fn(),
+}));
+
+describe("useDirectR2Upload", () => {
+  const file = new File(["file"], "photo.png", { type: "image/png" });
+  const originalFetch = global.fetch;
+  const originalXHR = global.XMLHttpRequest;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (resizeImageToMaxPx as jest.Mock).mockResolvedValue({
+      blob: new Blob(["blob"], { type: "image/png" }),
+      width: 1200,
+      height: 900,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    global.XMLHttpRequest = originalXHR as any;
+  });
+
+  it("uploads via presigned POST and reports progress", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        objectUrl: "https://cdn.example.com/photo.png",
+        post: { url: "https://upload", fields: { key: "value" } },
+      }),
+    });
+    global.fetch = fetchMock as any;
+
+    class MockXHR {
+      status = 204;
+      upload: any = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      open = jest.fn();
+      send = jest.fn(() => {
+        this.upload.onprogress?.({ lengthComputable: true, loaded: 5, total: 10 });
+        this.onload?.();
+      });
+      setRequestHeader = jest.fn();
+    }
+    global.XMLHttpRequest = jest.fn(() => new MockXHR()) as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      const info = await result.current.upload(file, { idempotencyKey: "abc", maxPx: 1000 });
+      expect(info).toMatchObject({ key: "photo.png", width: 1200, height: 900 });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/uploads/direct",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(result.current.progress).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("uploads via legacy PUT when provided", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        objectUrl: "https://cdn.example.com/photo.png",
+        legacyPut: { uploadUrl: "https://put", headers: undefined },
+      }),
+    });
+    global.fetch = fetchMock as any;
+
+    class MockXHR {
+      status = 201;
+      upload: any = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      headers: Record<string, string> = {};
+      open = jest.fn();
+      setRequestHeader = jest.fn((k: string, v: string) => {
+        this.headers[k] = v;
+      });
+      send = jest.fn(() => {
+        this.upload.onprogress?.({ lengthComputable: true, loaded: 10, total: 10 });
+        this.onload?.();
+      });
+    }
+    global.XMLHttpRequest = jest.fn(() => new MockXHR()) as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      const info = await result.current.upload(file, { idempotencyKey: "def" });
+      expect(info).toMatchObject({ key: "photo.png", width: 1200, height: 900 });
+    });
+  });
+
+  it("falls back to the file content type and tolerates missing POST fields", async () => {
+    (resizeImageToMaxPx as jest.Mock).mockResolvedValueOnce({
+      blob: new Blob(["blob"]),
+      width: 640,
+      height: 480,
+    });
+    const info: any = { objectUrl: "https://cdn.example.com/photo.png" };
+    let firstPostAccess = true;
+    Object.defineProperty(info, "post", {
+      get: jest.fn(() => {
+        if (firstPostAccess) {
+          firstPostAccess = false;
+          return { url: "https://upload", fields: undefined };
+        }
+        return undefined;
+      }),
+    });
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => info,
+    });
+    global.fetch = fetchMock as any;
+
+    class MockXHR {
+      status = 204;
+      upload: any = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      open = jest.fn();
+      send = jest.fn(() => {
+        this.upload.onprogress?.({ lengthComputable: false, loaded: 5, total: 10 });
+        this.onload?.();
+      });
+      setRequestHeader = jest.fn();
+    }
+    global.XMLHttpRequest = jest.fn(() => new MockXHR()) as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      await result.current.upload(file, { idempotencyKey: "fallback", maxPx: 2000 });
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(JSON.parse(requestInit.body as string).contentType).toBe(file.type);
+    expect(result.current.progress).toBeNull();
+    expect((global.XMLHttpRequest as jest.Mock).mock.results[0].value.open).toHaveBeenCalledWith(
+      "POST",
+      undefined,
+      true,
+    );
+  });
+
+  it("throws when the API response is not ok", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error("no json");
+      },
+    });
+    global.fetch = fetchMock as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      await expect(result.current.upload(file, { idempotencyKey: "ghi" })).rejects.toThrow("Failed to sign upload (500)");
+    });
+  });
+
+  it("throws when the presigned POST upload returns a non-success status", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        objectUrl: "https://cdn.example.com/photo.png",
+        post: { url: "https://upload", fields: {} },
+      }),
+    });
+    global.fetch = fetchMock as any;
+
+    class MockXHR {
+      status = 400;
+      upload: any = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      open = jest.fn();
+      send = jest.fn(() => {
+        this.onload?.();
+      });
+      setRequestHeader = jest.fn();
+    }
+    global.XMLHttpRequest = jest.fn(() => new MockXHR()) as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      await expect(result.current.upload(file, { idempotencyKey: "xyz" })).rejects.toThrow("Upload failed (400)");
+    });
+  });
+
+  it("throws when a presigned POST upload encounters a network error", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        objectUrl: "https://cdn.example.com/photo.png",
+        post: { url: "https://upload", fields: {} },
+      }),
+    });
+    global.fetch = fetchMock as any;
+
+    class MockXHR {
+      status = 0;
+      upload: any = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      open = jest.fn();
+      send = jest.fn(() => {
+        this.onerror?.();
+      });
+      setRequestHeader = jest.fn();
+    }
+    global.XMLHttpRequest = jest.fn(() => new MockXHR()) as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      await expect(result.current.upload(file, { idempotencyKey: "net" })).rejects.toThrow("Network error during upload");
+    });
+  });
+
+  it("throws when a legacy PUT upload returns a non-success status", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        objectUrl: "https://cdn.example.com/photo.png",
+        legacyPut: { uploadUrl: "https://put", headers: { "x-test": "1" } },
+      }),
+    });
+    global.fetch = fetchMock as any;
+
+    class MockXHR {
+      status = 500;
+      upload: any = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      open = jest.fn();
+      setRequestHeader = jest.fn();
+      send = jest.fn(() => {
+        this.onload?.();
+      });
+    }
+    global.XMLHttpRequest = jest.fn(() => new MockXHR()) as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      await expect(result.current.upload(file, { idempotencyKey: "put" })).rejects.toThrow("Upload failed (500)");
+    });
+  });
+
+  it("throws when a legacy PUT upload hits a network error", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        objectUrl: "https://cdn.example.com/photo.png",
+        legacyPut: { uploadUrl: "https://put", headers: {} },
+      }),
+    });
+    global.fetch = fetchMock as any;
+
+    class MockXHR {
+      status = 0;
+      upload: any = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      open = jest.fn();
+      setRequestHeader = jest.fn();
+      send = jest.fn(() => {
+        this.onerror?.();
+      });
+    }
+    global.XMLHttpRequest = jest.fn(() => new MockXHR()) as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      await expect(result.current.upload(file, { idempotencyKey: "put-net" })).rejects.toThrow("Network error during upload");
+    });
+  });
+  it("throws when no upload method is returned", async () => {
+    const fileWithoutType = new File(["file"], "photo", { type: "" });
+    (resizeImageToMaxPx as jest.Mock).mockResolvedValueOnce({
+      blob: new Blob(["blob"]),
+      width: 100,
+      height: 50,
+    });
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ objectUrl: "https://cdn.example.com/photo.png" }),
+    });
+    global.fetch = fetchMock as any;
+
+    const { result } = renderHook(() => useDirectR2Upload());
+
+    await act(async () => {
+      await expect(result.current.upload(fileWithoutType, { idempotencyKey: "jkl" })).rejects.toThrow("Missing upload method");
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(JSON.parse(requestInit.body as string).contentType).toBe("image/jpeg");
+  });
+});

--- a/packages/ui/src/hooks/tryon/__tests__/useTryOnController.test.tsx
+++ b/packages/ui/src/hooks/tryon/__tests__/useTryOnController.test.tsx
@@ -1,0 +1,247 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useTryOnController } from "../useTryOnController";
+import { useDirectR2Upload } from "../useDirectR2Upload";
+import { setTryOnCtx, logTryOnEvent } from "../analytics";
+
+jest.mock("../useDirectR2Upload", () => ({
+  useDirectR2Upload: jest.fn(),
+}));
+
+jest.mock("../analytics", () => ({
+  setTryOnCtx: jest.fn(),
+  logTryOnEvent: jest.fn(),
+}));
+
+type MockResponse = {
+  ok: boolean;
+  status?: number;
+  body?: { getReader(): { read(): Promise<{ done: boolean; value?: Uint8Array }> } };
+};
+
+function createStream(chunks: string[]): MockResponse["body"] {
+  let index = 0;
+  const encoder = new TextEncoder();
+  return {
+    getReader() {
+      return {
+        read: jest.fn(async () => {
+          if (index < chunks.length) {
+            const value = encoder.encode(chunks[index++]);
+            return { done: false, value };
+          }
+          return { done: true };
+        }),
+      };
+    },
+  };
+}
+
+describe("useTryOnController", () => {
+  const file = new File(["avatar"], "avatar.png", { type: "image/png" });
+  const uploadMock = jest.fn();
+  const originalFetch = global.fetch;
+  const originalCrypto = global.crypto;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (useDirectR2Upload as jest.Mock).mockReturnValue({ upload: uploadMock, progress: { done: 1, total: 2 }, error: "err" });
+    uploadMock.mockResolvedValue({ objectUrl: "https://cdn/avatar.png" });
+    (logTryOnEvent as jest.Mock).mockResolvedValue(undefined);
+    global.crypto = { randomUUID: () => "uuid-test" } as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    global.crypto = originalCrypto;
+  });
+
+  it("walks through upload, preprocess and enhance with retry", async () => {
+    (logTryOnEvent as jest.Mock).mockRejectedValueOnce(new Error("analytics"));
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ maskUrl: "mask" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ depthUrl: "depth" }) })
+      .mockRejectedValueOnce(new Error("pose"))
+      .mockResolvedValueOnce({ ok: true, body: createStream(["event: enhance\ndata: {\"progress\":0.5}\n\n"]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: createStream([
+          "event: enhance\ndata: {\"progress\":0.75}\n\n",
+          "event: final\ndata: {\"url\":\"https://result\"}\n\n",
+        ]),
+      });
+    global.fetch = fetchMock as any;
+
+    const { result } = renderHook(() => useTryOnController());
+
+    let jobId = "";
+    await act(async () => {
+      const info = await result.current.startUpload(file, { productId: "p1", mode: "garment" });
+      jobId = info.jobId;
+    });
+    expect(jobId).toBeTruthy();
+    const ctx = (setTryOnCtx as jest.Mock).mock.calls.at(-1)?.[0];
+    expect(ctx).toEqual(expect.objectContaining({ productId: "p1", mode: "garment", idempotencyKey: jobId }));
+    expect(uploadMock).toHaveBeenCalledWith(file, { idempotencyKey: jobId });
+
+    await act(async () => {
+      await result.current.preprocess({ imageUrl: "https://cdn/avatar.png", jobId });
+    });
+    expect(result.current.state.phase).toBe("preview");
+    expect(result.current.state.maskUrl).toBe("mask");
+    expect(result.current.state.depthUrl).toBe("depth");
+    expect(result.current.canEnhance).toBe(true);
+
+    await act(async () => {
+      await result.current.enhance({
+        mode: "garment",
+        productId: "p1",
+        sourceImageUrl: "https://cdn/avatar.png",
+        garmentAssets: {},
+      });
+    });
+
+    expect(result.current.state.phase).toBe("done");
+    expect(result.current.state.resultUrl).toBe("https://result");
+    expect(result.current.progress).toBe(1);
+    expect(logTryOnEvent).toHaveBeenCalledWith("TryOnPreviewShown", expect.any(Object));
+    expect(logTryOnEvent).toHaveBeenCalledWith("TryOnEnhanced");
+  });
+
+  it("marks failure when the enhance response is not ok", async () => {
+    (useDirectR2Upload as jest.Mock).mockReturnValue({ upload: uploadMock, progress: null, error: null });
+    uploadMock.mockResolvedValue({ objectUrl: "https://cdn/avatar.png" });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, body: undefined })
+      .mockResolvedValueOnce({ ok: false, status: 500, body: undefined });
+    global.fetch = fetchMock as any;
+
+    const { result } = renderHook(() => useTryOnController());
+
+    await act(async () => {
+      await result.current.startUpload(file, {});
+    });
+    await act(async () => {
+      await result.current.enhance({
+        mode: "garment",
+        productId: "p1",
+        sourceImageUrl: "https://cdn/avatar.png",
+        garmentAssets: {},
+      });
+    });
+
+    expect(result.current.state.phase).toBe("failed");
+    expect(result.current.state.error).toContain("Enhance failed");
+  });
+
+  it("handles preprocess fetch failures by falling back to empty objects", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("segment"))
+      .mockRejectedValueOnce(new Error("depth"))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ poseUrl: "pose-url" }) })
+      .mockResolvedValue({ ok: true, body: createStream(["event: final\ndata: {\"url\":\"https://result\"}\n\n"]) });
+    global.fetch = fetchMock as any;
+
+    const { result } = renderHook(() => useTryOnController());
+
+    let jobId = "";
+    await act(async () => {
+      const info = await result.current.startUpload(file, {});
+      jobId = info.jobId;
+    });
+
+    await act(async () => {
+      await result.current.preprocess({ imageUrl: "https://cdn/avatar.png", jobId });
+    });
+
+    expect(result.current.state.phase).toBe("preview");
+    expect(result.current.state.maskUrl).toBeUndefined();
+    expect(result.current.state.depthUrl).toBeUndefined();
+    expect(result.current.state.poseUrl).toBe("pose-url");
+  });
+
+  it("logs try-on errors from stream events", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ maskUrl: "mask" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ depthUrl: "depth" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ poseUrl: "pose" }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: createStream([
+          "event: enhance\ndata: {\"progress\":0.25}\n\n",
+          "event: error\ndata: {\"code\":\"E1\",\"message\":\"boom\"}\n\n",
+          "event: final\ndata: {\"url\":\"https://final\"}\n\n",
+        ]),
+      });
+    global.fetch = fetchMock as any;
+
+    const { result } = renderHook(() => useTryOnController());
+
+    let jobId = "";
+    await act(async () => {
+      const info = await result.current.startUpload(file, {});
+      jobId = info.jobId;
+    });
+    await waitFor(() => expect(result.current.state.phase).toBe("preprocessed"));
+    await act(async () => {
+      await result.current.preprocess({ imageUrl: "https://cdn/avatar.png", jobId });
+    });
+    await waitFor(() => expect(result.current.state.phase).toBe("preview"));
+    await act(async () => {
+      await result.current.enhance({
+        mode: "garment",
+        productId: "p1",
+        sourceImageUrl: "https://cdn/avatar.png",
+        garmentAssets: {},
+      });
+    });
+
+    expect(logTryOnEvent).toHaveBeenCalledWith("TryOnError", { code: "E1", message: "boom" });
+    expect(result.current.state.resultUrl).toBe("https://final");
+    expect(result.current.state.phase).toBe("done");
+  });
+
+  it("handles data-less chunks and defaults error messages", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ maskUrl: "mask" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ depthUrl: "depth" }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ poseUrl: "pose" }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: createStream([
+          "event: ping\n\n",
+          `event: error\ndata: ${JSON.stringify({ code: "E2" })}\n\n`,
+          `event: final\ndata: ${JSON.stringify({ url: "https://retry" })}\n\n`,
+        ]),
+      });
+    global.fetch = fetchMock as any;
+
+    const { result } = renderHook(() => useTryOnController());
+
+    let jobId = "";
+    await act(async () => {
+      const info = await result.current.startUpload(file, {});
+      jobId = info.jobId;
+    });
+    await act(async () => {
+      await result.current.preprocess({ imageUrl: "https://cdn/avatar.png", jobId });
+    });
+
+    await act(async () => {
+      await result.current.enhance({
+        mode: "garment",
+        productId: "p1",
+        sourceImageUrl: "https://cdn/avatar.png",
+        garmentAssets: {},
+      });
+    });
+
+    expect(result.current.state.error).toBe("Unknown error");
+    expect(result.current.state.resultUrl).toBe("https://retry");
+    expect(logTryOnEvent).toHaveBeenCalledWith("TryOnError", { code: "E2", message: undefined });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit coverage for the try-on reducer/derived state helpers
- exercise success and failure paths of the image resize helper
- cover the controller and direct upload hooks across success, retry, and error flows

## Testing
- pnpm --filter @acme/ui exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --testPathPattern tryon --coverage
- pnpm --filter @acme/ui exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --testPathPattern tryon --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dbf8aefed4832fb3dc41f32676cdc5