### PR TITLE
Fix CMS Jest transform ignore for pnpm nested deps

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -70,8 +70,10 @@ module.exports = {
   },
   // Keep in sync with monorepo base so internal workspace packages are transformed
   transformIgnorePatterns: [
-    // Allow ESM packages used in tests to be transformed by ts-jest
-    "/node_modules/(?!(jose|next-auth|ulid|@upstash/redis|uncrypto|@acme|msw|until-async)/)",
+    // Allow ESM packages used in tests to be transformed by ts-jest. pnpm nests
+    // dependencies under `.pnpm/<pkg>/node_modules/`, so ensure those paths are
+    // also matched when whitelisting specific modules.
+    "/node_modules/(?!(?:\\.pnpm/[^/]+/node_modules/)?(jose|next-auth|ulid|@upstash/redis|uncrypto|@acme|msw|until-async)/)",
   ],
   // Collect coverage only from the CMS source code; exclude declarations and tests.
   collectCoverage: true,


### PR DESCRIPTION
## Summary
- update the CMS Jest configuration so pnpm-nested ESM dependencies like `until-async` are transformed during tests

## Testing
- pnpm exec jest --config apps/cms/jest.config.cjs --testPathPattern useShopEditorSubmit.serverValidation --listTests

------
https://chatgpt.com/codex/tasks/task_e_68dc023cb57c832fa6b7da924470690d