### PR TITLE
fix(cms): transpile esm dependencies in jest config

### DIFF
--- a/apps/cms/jest.config.cjs
+++ b/apps/cms/jest.config.cjs
@@ -58,13 +58,22 @@ module.exports = {
     "^react-chartjs-2$": "<rootDir>/test/__mocks__/react-chartjs-2.ts",
   },
   transform: {
-    "^.+\\.[tj]sx?$": [
+    "^.+\\.(ts|tsx)$": [
       "ts-jest",
       {
         tsconfig: path.resolve(__dirname, "tsconfig.test.json"),
         useESM: false,
         babelConfig: false,
         diagnostics: false,
+      },
+    ],
+    // Ensure ESM JavaScript from dependencies is transpiled to CJS for Jest
+    "^.+\\.(mjs|cjs|js)$": [
+      "babel-jest",
+      {
+        presets: [
+          ["@babel/preset-env", { targets: { node: "current" }, modules: "commonjs" }],
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Summary
- update the CMS Jest transform configuration to compile TypeScript with ts-jest and JavaScript with babel-jest
- ensure ESM-only dependencies such as msw and until-async are transpiled to CommonJS for Jest

## Testing
- pnpm --filter @apps/cms exec jest --config jest.config.cjs --listTests --testPathPattern sanity.server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc06ede920832f8c6e86a17291d114