### PR TITLE
Fix configurator step tests without provider dependencies

### DIFF
--- a/apps/cms/src/app/cms/configurator/steps/__tests__/StepShopPage.test.tsx
+++ b/apps/cms/src/app/cms/configurator/steps/__tests__/StepShopPage.test.tsx
@@ -13,6 +13,11 @@ jest.mock("../../hooks/useStepCompletion", () => ({
   default: () => [false, markComplete],
 }));
 
+jest.mock("../../hooks/useThemeLoader", () => ({
+  __esModule: true,
+  useThemeLoader: () => ({}),
+}));
+
 jest.mock("next/image", () => {
   const React = require("react");
   // Stub that avoids <img> to satisfy ds/no-naked-img and a11y rules in tests


### PR DESCRIPTION
## Summary
- mock the theme loader hook in `StepShopPage` tests so they no longer require the configurator context
- align `StepShopDetails` tests with the current UI surface and expose helper state for updating logo validation

## Testing
- `pnpm --filter @apps/cms exec jest --ci --runInBand --coverage=false --runTestsByPath $(pwd)/apps/cms/src/app/cms/configurator/steps/__tests__/StepShopPage.test.tsx $(pwd)/apps/cms/src/app/cms/configurator/steps/__tests__/StepShopDetails.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68dc1f6c8d80832f89c656b5f1ee1181