### PR TITLE
Handle init-shop disk errors and adjust CMS tests

### DIFF
--- a/apps/cms/src/app/api/configurator/init-shop/route.ts
+++ b/apps/cms/src/app/api/configurator/init-shop/route.ts
@@ -75,7 +75,8 @@ export async function POST(req: Request) {
       await writeJsonFile(path.join(dir, "categories.json"), categories);
     }
     return NextResponse.json({ success: true });
-  } catch {
-    return NextResponse.json({ error: t("api.common.invalidRequest") }, { status: 400 });
+  } catch (error) {
+    const key = error instanceof Error && error.message ? error.message : "api.common.invalidRequest";
+    return NextResponse.json({ error: t(key) }, { status: 400 });
   }
 }

--- a/apps/cms/src/app/cms/shop/[shop]/UpgradeSummaryClient.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/UpgradeSummaryClient.tsx
@@ -14,7 +14,15 @@ function useColumns() {
   const t = useTranslations();
   const cols: Column<ComponentChange>[] = [
     { header: String(t("cms.upgrade.table.package")), render: (row) => row.name },
-    { header: String(t("cms.upgrade.table.current")), render: (row) => row.from ?? String(t("common.none")) },
+    {
+      header: String(t("cms.upgrade.table.current")),
+      render: (row) =>
+        row.from ?? (
+          <span aria-label={String(t("common.none"))} title={String(t("common.none"))}>
+            —
+          </span>
+        ),
+    },
     { header: String(t("cms.upgrade.table.new")), render: (row) => row.to },
     {
       header: String(t("cms.upgrade.table.changelog")),
@@ -30,7 +38,13 @@ function useColumns() {
             {t("cms.upgrade.table.view")}
           </a>
         ) : (
-          <span className="text-muted-foreground">{t("common.none")}</span>
+          <span
+            className="text-muted-foreground"
+            aria-label={String(t("common.none"))}
+            title={String(t("common.none"))}
+          >
+            —
+          </span>
         ),
     },
   ];

--- a/apps/cms/src/app/cms/shop/[shop]/products/page.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/products/page.test.tsx
@@ -61,6 +61,8 @@ jest.mock("@ui/components/atoms", () => {
   const React = require("react");
   return {
     __esModule: true,
+    Alert: ({ heading, children, ...props }: any) =>
+      React.createElement("div", { role: "alert", ...props }, heading ?? children ?? null),
     Progress: ({ label }: any) =>
       React.createElement("div", { role: label ? "progressbar" : undefined }, label ?? null),
     Tag: ({ children, ...props }: any) =>


### PR DESCRIPTION
## Summary
- propagate underlying error messages from the init shop API so disk failures surface in responses
- render missing package values as em dashes with accessibility labels in the upgrade summary client
- extend the CMS products page test shadcn mock to include an Alert stub used by the page

## Testing
- pnpm --filter @apps/cms exec -- jest --runInBand --detectOpenHandles --config ./jest.config.cjs --runTestsByPath src/app/api/configurator/init-shop/__tests__/legacy/route.test.ts --coverage=false
- pnpm --filter @apps/cms exec -- jest --runInBand --detectOpenHandles --config ./jest.config.cjs --runTestsByPath src/app/cms/shop/[shop]/products/page.test.tsx --coverage=false
- pnpm --filter @apps/cms exec -- jest --runInBand --detectOpenHandles --config ./jest.config.cjs --runTestsByPath src/app/cms/shop/[shop]/__tests__/UpgradeSummary.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dc1e67b3f0832f845fa9c1de398d4d