### PR TITLE
Fix preset controls fallbacks and form field error wrapper

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/themes/PresetControls.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/themes/PresetControls.tsx
@@ -21,19 +21,29 @@ export default function PresetControls({
   isPresetTheme,
 }: Props) {
   const t = useTranslations();
+  const translate = (key: string, fallback: string) => {
+    const value = t(key);
+    if (typeof value === "string" && value !== key) {
+      return value;
+    }
+    return fallback;
+  };
+  const presetPlaceholder = translate("cms.themes.presetNamePlaceholder", "Preset name");
+  const saveLabel = translate("cms.themes.savePreset", "Save Preset");
+  const deleteLabel = translate("cms.themes.deletePreset", "Delete Preset");
   return (
     <Inline alignY="center" gap={2}>
       <Input
-        placeholder={t("cms.themes.presetNamePlaceholder") as string}
+        placeholder={presetPlaceholder}
         value={presetName}
         onChange={(e: ChangeEvent<HTMLInputElement>) => setPresetName(e.target.value)}
       />
       <Button type="button" onClick={handleSavePreset} disabled={!presetName.trim()}>
-        {t("cms.themes.savePreset")}
+        {saveLabel}
       </Button>
       {isPresetTheme && (
         <Button type="button" onClick={handleDeletePreset}>
-          {t("cms.themes.deletePreset")}
+          {deleteLabel}
         </Button>
       )}
     </Inline>

--- a/packages/ui/src/components/molecules/FormField.tsx
+++ b/packages/ui/src/components/molecules/FormField.tsx
@@ -54,6 +54,13 @@ export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
       const h = typeof style.height === "number" ? `${style.height}px` : style.height;
       sizeClasses.push(`h-[${h}]`);
     }
+    const errorChildren = React.Children.toArray(error ?? null);
+    const hasError = errorChildren.length > 0;
+    const isTextOnly = errorChildren.every(
+      (child) => typeof child === "string" || typeof child === "number",
+    );
+    const ErrorContainer = isTextOnly ? "p" : "div";
+
     return (
       <div
         ref={ref}
@@ -74,10 +81,10 @@ export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
           )}
         </label>
         {children}
-        {error && (
-          <p className={ERROR_TEXT_CLASSES} data-token={DANGER_TOKEN}>
+        {hasError && (
+          <ErrorContainer className={ERROR_TEXT_CLASSES} data-token={DANGER_TOKEN}>
             {error}
-          </p>
+          </ErrorContainer>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary
- add graceful fallbacks in PresetControls so untranslated keys show friendly copy
- adjust FormField error rendering to pick a block element based on the provided error content and avoid invalid markup

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1e3cb48c832f8bbe666acf5a43d1