### PR TITLE
Fix ts-jest preset handling of JS modules

### DIFF
--- a/packages/config/jest.preset.cjs
+++ b/packages/config/jest.preset.cjs
@@ -38,6 +38,12 @@ const tsJestOptions = {
 
 const transform = {
   "^.+\\.(ts|tsx)$": ["ts-jest", tsJestOptions],
+  "^.+\\.[tj]sx?$": [
+    "babel-jest",
+    {
+      presets: [["@babel/preset-env", { targets: { node: "current" }, modules: "commonjs" }]],
+    },
+  ],
 };
 
 /** @type {import('jest').Config} */

--- a/packages/config/tsconfig.test.json
+++ b/packages/config/tsconfig.test.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": ["@testing-library/jest-dom", "jest", "node"],
     "noEmit": true,
+    "allowJs": true,
     "rootDir": ".",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
## Summary
- route JS files in the shared Jest preset through `babel-jest` so that ESM dependencies are not compiled by `ts-jest`
- enable `allowJs` in the config package test tsconfig used by the preset to keep TypeScript happy when JavaScript helpers are transformed

## Testing
- pnpm --filter @apps/api test -- apps/api

------
https://chatgpt.com/codex/tasks/task_e_68dc1fcf4fd4832fa4c0388cbb24b353