### PR TITLE
Fix ShopLocalizationSection test mocks for UI atoms

### DIFF
--- a/apps/cms/src/app/cms/shop/[shop]/settings/sections/__tests__/ShopLocalizationSection.test.tsx
+++ b/apps/cms/src/app/cms/shop/[shop]/settings/sections/__tests__/ShopLocalizationSection.test.tsx
@@ -14,7 +14,7 @@ jest.mock(
 );
 
 jest.mock(
-  "@ui/components",
+  "@ui/components/atoms",
   () => {
     const React = require("react");
     const SelectContent = Object.assign(
@@ -67,13 +67,6 @@ jest.mock(
     const SelectValue = ({ placeholder, children }: any) => children ?? placeholder;
     return {
       Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
-      FormField: ({ children, label, htmlFor, error }: any) => (
-        <div>
-          <label htmlFor={htmlFor}>{label}</label>
-          {children}
-          {error}
-        </div>
-      ),
       Input: (props: any) => <input {...props} />,
       Select,
       SelectTrigger,
@@ -85,6 +78,20 @@ jest.mock(
       Chip: ({ children, ...props }: any) => <span {...props}>{children}</span>,
     };
   },
+  { virtual: true },
+);
+
+jest.mock(
+  "@ui/components/molecules",
+  () => ({
+    FormField: ({ children, label, htmlFor, error }: any) => (
+      <div>
+        <label htmlFor={htmlFor}>{label}</label>
+        {children}
+        {error}
+      </div>
+    ),
+  }),
   { virtual: true },
 );
 


### PR DESCRIPTION
## Summary
- update the ShopLocalizationSection test to mock `@ui/components/atoms` rather than the umbrella module
- add a lightweight mock for `@ui/components/molecules` so the form field label mapping works with the simplified atoms mock

## Testing
- Not run (jest single-test command hung in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc1e2760d8832fb114914af57db719