### PR TITLE
Fix order tracking template test translations

### DIFF
--- a/packages/ui/src/components/templates/__tests__/OrderTrackingTemplate.test.tsx
+++ b/packages/ui/src/components/templates/__tests__/OrderTrackingTemplate.test.tsx
@@ -1,5 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+const translations: Record<string, string> = {
+  "order.tracking.title": "Track your order",
+  "order.reference": "Order ref",
+  "order.shippingTo": "Shipping to",
+};
+
+jest.mock("@acme/i18n", () => ({
+  useTranslations: () => (key: string) => translations[key] ?? key,
+}));
+
 import { OrderTrackingTemplate } from "../OrderTrackingTemplate";
 
 describe("OrderTrackingTemplate", () => {


### PR DESCRIPTION
## Summary
- mock the @acme/i18n hook in the order tracking template test so the rendered text matches the expectations

## Testing
- pnpm --filter @acme/ui test:quick -- OrderTrackingTemplate.test.tsx *(fails: coverage thresholds enforced by the test configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2763dd30832fa0e8007121eb5002