### PR TITLE
Ensure Logo renders accessible role

### DIFF
--- a/packages/ui/src/components/atoms/Logo.tsx
+++ b/packages/ui/src/components/atoms/Logo.tsx
@@ -107,6 +107,7 @@ export const Logo = React.forwardRef<HTMLImageElement, LogoProps>(
       height: typeof imageHeight === "number" ? imageHeight : undefined,
       sizes,
       className: cn(className),
+      role: props.role ?? "img",
       ...(computedSrcSet ? { srcSet: computedSrcSet } : {}),
     };
 


### PR DESCRIPTION
## Summary
- default the Logo component to use an explicit `role="img"` when rendering via `next/image`
- preserve any consumer-provided role overrides while ensuring accessibility in mocked environments

## Testing
- JEST_DISABLE_COVERAGE_THRESHOLD=1 pnpm --filter @acme/ui exec jest --runInBand src/components/atoms/__tests__/Logo.test.tsx *(fails due to package-wide coverage thresholds, but the targeted tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68dc27704edc832fa88f5ded669f2c0b