### PR TITLE
Add accessible description to presets modal

### DIFF
--- a/packages/i18n/src/de.json
+++ b/packages/i18n/src/de.json
@@ -415,6 +415,7 @@
   "cms.builder.presets.save.success": "Preset saved",
   "cms.builder.presets.search.aria": "Search presets",
   "cms.builder.presets.search.placeholder": "Search sections and presets...",
+  "cms.builder.presets.sectionLibrary.description": "Durchstöbern und suchen Sie nach Abschnittsvorlagen, um Ihrer Seite schnell Inhalte hinzuzufügen.",
   "cms.builder.presets.sectionLibrary.title": "Section Library",
   "cms.builder.preview.button": "Button",
   "cms.builder.preview.disabled": "Preview disabled",

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -452,6 +452,7 @@
   "cms.builder.presets.save.success": "Preset saved",
   "cms.builder.presets.search.aria": "Search presets",
   "cms.builder.presets.search.placeholder": "Search sections and presets...",
+  "cms.builder.presets.sectionLibrary.description": "Browse and search section presets to quickly add content to your page.",
   "cms.builder.presets.sectionLibrary.title": "Section Library",
   "cms.builder.preview.button": "Button",
   "cms.builder.preview.disabled": "Preview disabled",

--- a/packages/i18n/src/it.json
+++ b/packages/i18n/src/it.json
@@ -439,6 +439,7 @@
   "cms.builder.presets.save.success": "Preset saved",
   "cms.builder.presets.search.aria": "Search presets",
   "cms.builder.presets.search.placeholder": "Search sections and presets...",
+  "cms.builder.presets.sectionLibrary.description": "Esplora e cerca i preset delle sezioni per aggiungere rapidamente contenuti alla pagina.",
   "cms.builder.presets.sectionLibrary.title": "Section Library",
   "cms.builder.preview.button": "Pulsante",
   "cms.builder.preview.disabled": "Preview disabled",

--- a/packages/ui/src/components/cms/page-builder/PresetsModal.tsx
+++ b/packages/ui/src/components/cms/page-builder/PresetsModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Dialog, DialogContent, DialogTitle, DialogTrigger, Button } from "../../atoms/shadcn";
+import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger, Button } from "../../atoms/shadcn";
 import { Tooltip } from "../../atoms";
 import Image from "next/image";
 import { useEffect, useMemo, useState } from "react";
@@ -176,6 +176,7 @@ export default function PresetsModal({ onInsert, sourceUrl, open, onOpenChange, 
       )}
       <DialogContent>
         <DialogTitle>{t("cms.builder.presets.sectionLibrary.title")}</DialogTitle>
+        <DialogDescription>{t("cms.builder.presets.sectionLibrary.description")}</DialogDescription>
         {loadError && (
           <div className="rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800">
             {loadError}


### PR DESCRIPTION
## Summary
- add an explicit description to the presets dialog content to satisfy the Radix accessibility requirement
- localize the new description string across the supported locales

## Testing
- `pnpm --filter @acme/ui exec jest --runInBand --detectOpenHandles --config jest.config.cjs --testPathPattern PresetsModal.test.tsx --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68dc2780ff28832faf04d792e72af04c