### PR TITLE
Fix MediaManager tests for updated delete button

### DIFF
--- a/packages/ui/src/components/cms/tests/MediaManager.delete.test.tsx
+++ b/packages/ui/src/components/cms/tests/MediaManager.delete.test.tsx
@@ -133,7 +133,7 @@ describe("MediaManager – delete", () => {
         onMetadataUpdate={mockMetadataUpdate}
       />
     );
-    fireEvent.click(screen.getAllByRole("menuitem", { name: /Delete/i })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: /Delete media/i })[0]);
     await waitFor(() =>
       expect(mockDelete).toHaveBeenCalledWith("s", "/img.jpg")
     );

--- a/packages/ui/src/components/cms/tests/MediaManager.filtering.test.tsx
+++ b/packages/ui/src/components/cms/tests/MediaManager.filtering.test.tsx
@@ -135,10 +135,14 @@ describe("MediaManager – filtering", () => {
         onMetadataUpdate={mockMetadataUpdate}
       />
     );
-    expect(screen.getAllByRole("menuitem", { name: /Delete/i })).toHaveLength(2);
+    expect(
+      screen.getAllByRole("button", { name: /Delete media/i })
+    ).toHaveLength(2);
     fireEvent.change(screen.getByPlaceholderText("Search media..."), {
       target: { value: "dog" },
     });
-    expect(screen.getAllByRole("menuitem", { name: /Delete/i })).toHaveLength(1);
+    expect(
+      screen.getAllByRole("button", { name: /Delete media/i })
+    ).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- adjust the MediaManager delete test to target the delete action button by its accessible label
- update the filtering test to count delete action buttons using the new button role

## Testing
- ⚠️ `./node_modules/.bin/jest --testPathPattern MediaManager --runInBand` *(fails: node: not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc28094b30832f99e465a5f01be1f7