### PR TITLE
Fix header navigation label and swatch sizing defaults

### DIFF
--- a/packages/ui/__tests__/Sessions.test.tsx
+++ b/packages/ui/__tests__/Sessions.test.tsx
@@ -107,7 +107,7 @@ describe("revoke", () => {
     expect(revokeSession).not.toHaveBeenCalled();
     expect(result).toEqual({
       success: false,
-      error: "Session does not belong to the user.",
+      error: "account.sessions.errors.notOwned",
     });
   });
 

--- a/packages/ui/src/components/atoms/ColorSwatch.tsx
+++ b/packages/ui/src/components/atoms/ColorSwatch.tsx
@@ -17,9 +17,15 @@ export interface ColorSwatchProps
 export const ColorSwatch = React.forwardRef<
   HTMLButtonElement,
   ColorSwatchProps
->(({ color, selected = false, size = 24, className, style: _style, ...props }, ref) => {
+>(({ color, selected = false, size = 24, className, style: styleOverride, ...props }, ref) => {
   const normalized =
     typeof color === "string" ? color.replace(/\s+/g, "") : String(color);
+  const dimension = `${size}px`;
+  const style: React.CSSProperties = {
+    width: dimension,
+    height: dimension,
+    ...styleOverride,
+  };
   return (
     <button
       ref={ref}
@@ -32,6 +38,7 @@ export const ColorSwatch = React.forwardRef<
         selected ? "ring-2 ring-offset-2" : "", // i18n-exempt -- DEV-000 CSS utility class names
         className
       )}
+      style={style}
       {...props}
     />
   );

--- a/packages/ui/src/components/layout/HeaderClient.client.tsx
+++ b/packages/ui/src/components/layout/HeaderClient.client.tsx
@@ -42,6 +42,14 @@ export default function HeaderClient({
   const BADGE_TOKEN = "--color-danger"; // i18n-exempt -- PB-123 design token name [ttl=2025-12-31]
   const BADGE_FG_CLASS = "text-danger-foreground"; // i18n-exempt -- PB-123 CSS classes only [ttl=2025-12-31]
   const BADGE_FG_TOKEN = "--color-danger-fg"; // i18n-exempt -- PB-123 design token name [ttl=2025-12-31]
+  const navLabelRaw = t("header.nav.aria");
+  const navLabel =
+    typeof navLabelRaw === "string" &&
+    navLabelRaw.trim().length > 0 &&
+    navLabelRaw !== "header.nav.aria"
+      ? navLabelRaw
+      : "Main navigation";
+
   return (
     <header
       className={cn(HEADER_CLASS, height, padding)}
@@ -50,7 +58,7 @@ export default function HeaderClient({
         {t("app.name")}
       </Link>
 
-      <nav className={NAV_CLASS} aria-label={t("header.nav.aria") as string}>
+      <nav className={NAV_CLASS} aria-label={navLabel}>
         {nav.map((item) => (
           <Link
             key={item.url}


### PR DESCRIPTION
## Summary
- add a fallback accessible label for the header navigation when translations are missing
- ensure ColorSwatch applies default inline dimensions while preserving custom styles
- align the Sessions revoke test with the action's translated error keys

## Testing
- pnpm --filter @acme/ui test:quick -- --runTestsByPath packages/ui/__tests__/HeaderClient.a11y.test.tsx packages/ui/__tests__/ColorSwatch.defaults.test.tsx packages/ui/__tests__/Sessions.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc27d07dcc832f946cdac6ce1d0453