### PR TITLE
Fix ColorSwatch inline styles and stabilize GridOverlay tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -186,7 +186,12 @@ try {
 if (__mswServer) {
   beforeAll(() => __mswServer?.listen?.({ onUnhandledRequest: "error" }));
   afterEach(() => __mswServer?.resetHandlers?.());
-  afterAll(() => __mswServer?.close?.());
+  afterAll(() => {
+    if (typeof globalThis.fetch !== "function") {
+      return;
+    }
+    __mswServer?.close?.();
+  });
 }
 
 // Reset shared auth/config mocks between tests to avoid leakage across suites

--- a/packages/ui/__tests__/GridOverlay.test.tsx
+++ b/packages/ui/__tests__/GridOverlay.test.tsx
@@ -13,7 +13,11 @@ describe("GridOverlay", () => {
 
   test.each(cases)("renders %s columns", ({ gridCols, expected }) => {
     const { container } = render(<GridOverlay gridCols={gridCols} />);
-    const grid = container.firstChild as HTMLElement;
+    const grid = container.querySelector(
+      '[data-cy="pb-grid-overlay"]'
+    ) as HTMLElement;
+
+    expect(grid).toBeTruthy();
 
     expect(grid.children).toHaveLength(expected);
     expect(grid).toHaveStyle(`grid-template-columns: repeat(${expected}, 1fr)`);

--- a/packages/ui/src/components/atoms/ColorSwatch.tsx
+++ b/packages/ui/src/components/atoms/ColorSwatch.tsx
@@ -20,6 +20,13 @@ export const ColorSwatch = React.forwardRef<
 >(({ color, selected = false, size = 24, className, style: _style, ...props }, ref) => {
   const normalized =
     typeof color === "string" ? color.replace(/\s+/g, "") : String(color);
+  const dimension = Number.isFinite(size) && size > 0 ? size : 24;
+  const style: React.CSSProperties = {
+    width: `${dimension}px`,
+    height: `${dimension}px`,
+    backgroundColor: color,
+    ..._style,
+  };
   return (
     <button
       ref={ref}
@@ -27,11 +34,12 @@ export const ColorSwatch = React.forwardRef<
       className={cn(
         "rounded-full border", // i18n-exempt -- DEV-000 CSS utility class names
         // Keep Tailwind utility classes for runtime styling
-        `h-[${size}px] w-[${size}px]`,
+        `h-[${dimension}px] w-[${dimension}px]`,
         `bg-[${normalized}]`,
         selected ? "ring-2 ring-offset-2" : "", // i18n-exempt -- DEV-000 CSS utility class names
         className
       )}
+      style={style}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- add inline sizing/background styles to the ColorSwatch atom while retaining existing Tailwind classes
- target the rendered overlay element in the GridOverlay test so column assertions match the component markup
- guard Jest's MSW shutdown from running when `globalThis.fetch` is unavailable to prevent teardown crashes

## Testing
- JEST_DISABLE_COVERAGE_THRESHOLD=1 CI=1 pnpm exec jest --runInBand --config jest.config.cjs --runTestsByPath __tests__/ColorSwatch.test.tsx __tests__/GridOverlay.test.tsx src/components/account/__tests__/ProfileForm.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dc27ed4cf0832facf3173230bcdaea