### PR TITLE
Fix progress bar width and resizer handle wiring

### DIFF
--- a/packages/ui/src/components/atoms/Progress.tsx
+++ b/packages/ui/src/components/atoms/Progress.tsx
@@ -11,6 +11,11 @@ export interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
   ({ value, label, className, labelClassName, ...props }, ref) => {
+    const clampedValue = Number.isFinite(value)
+      ? Math.min(100, Math.max(0, value))
+      : 0;
+    const width = `${clampedValue}%`;
+
     return (
       <div ref={ref} className={cn("space-y-1", className)} {...props}>
         <div
@@ -21,10 +26,10 @@ export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
         >
           <div
             className={cn(
-              "bg-primary h-full transition-all", // i18n-exempt -- UI-000: CSS utility class names [ttl=2026-01-31]
-              `[--pct:${value}%] w-[var(--pct)]` // i18n-exempt -- UI-000: CSS utility class names (CSS var usage) [ttl=2026-01-31]
+              "bg-primary h-full transition-all" // i18n-exempt -- UI-000: CSS utility class names [ttl=2026-01-31]
             )}
             data-token="--color-primary" // i18n-exempt -- UI-000: design token attribute, not user copy [ttl=2026-01-31]
+            style={{ width }}
           />
         </div>
         {label ? (

--- a/packages/ui/src/components/cms/page-builder/BlockResizer.tsx
+++ b/packages/ui/src/components/cms/page-builder/BlockResizer.tsx
@@ -1,17 +1,149 @@
 "use client";
 
 import { useTranslations } from "@acme/i18n";
+import type { PointerEvent } from "react";
+
+type ResizeHandle = "se" | "ne" | "sw" | "nw" | "e" | "w" | "n" | "s";
+type SpacingType = "margin" | "padding";
+type SpacingSide = "top" | "bottom" | "left" | "right";
 
 interface Props {
   selected: boolean;
-  startResize: (e: React.PointerEvent, handle?: "se" | "ne" | "sw" | "nw" | "e" | "w" | "n" | "s") => void;
-  startSpacing: (
-    e: React.PointerEvent,
-    type: "margin" | "padding",
-    side: "top" | "bottom" | "left" | "right",
-  ) => void;
-  startRotate?: (e: React.PointerEvent) => void;
+  startResize: (e: PointerEvent, handle?: ResizeHandle) => void;
+  startSpacing: (e: PointerEvent, type: SpacingType, side: SpacingSide) => void;
+  startRotate?: (e: PointerEvent) => void;
 }
+
+const cornerHandles: Array<{
+  handle: ResizeHandle;
+  className: string;
+  ariaLabel: string;
+}> = [
+  {
+    handle: "nw",
+    className:
+      "pointer-events-auto absolute -top-2 -start-2 h-6 w-6 cursor-nwse-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Resize from top-left",
+  },
+  {
+    handle: "ne",
+    className:
+      "pointer-events-auto absolute -top-2 -end-2 h-6 w-6 cursor-nesw-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Resize from top-right",
+  },
+  {
+    handle: "sw",
+    className:
+      "pointer-events-auto absolute -bottom-2 -start-2 h-6 w-6 cursor-nesw-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Resize from bottom-left",
+  },
+  {
+    handle: "se",
+    className:
+      "pointer-events-auto absolute -end-2 -bottom-2 h-6 w-6 cursor-nwse-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Resize from bottom-right",
+  },
+];
+
+const edgeHandles: Array<{
+  handle: ResizeHandle;
+  className: string;
+  ariaLabel: string;
+}> = [
+  {
+    handle: "n",
+    className:
+      "pointer-events-auto absolute -top-2 start-1/2 h-6 w-8 -translate-x-1/2 cursor-ns-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Resize from top",
+  },
+  {
+    handle: "s",
+    className:
+      "pointer-events-auto absolute -bottom-2 start-1/2 h-6 w-8 -translate-x-1/2 cursor-ns-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Resize from bottom",
+  },
+  {
+    handle: "w",
+    className:
+      "pointer-events-auto absolute top-1/2 -start-2 h-8 w-6 -translate-y-1/2 cursor-ew-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Resize from left",
+  },
+  {
+    handle: "e",
+    className:
+      "pointer-events-auto absolute top-1/2 -end-2 h-8 w-6 -translate-y-1/2 cursor-ew-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Resize from right",
+  },
+];
+
+const spacingHandles: Array<{
+  type: SpacingType;
+  side: SpacingSide;
+  className: string;
+  ariaLabel: string;
+}> = [
+  {
+    type: "margin",
+    side: "top",
+    className:
+      "pointer-events-auto absolute -top-3 start-1/2 h-2 w-10 -translate-x-1/2 cursor-n-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Adjust margin top",
+  },
+  {
+    type: "margin",
+    side: "bottom",
+    className:
+      "pointer-events-auto absolute -bottom-3 start-1/2 h-2 w-10 -translate-x-1/2 cursor-s-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Adjust margin bottom",
+  },
+  {
+    type: "margin",
+    side: "left",
+    className:
+      "pointer-events-auto absolute top-1/2 -left-3 h-10 w-2 -translate-y-1/2 cursor-w-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Adjust margin left",
+  },
+  {
+    type: "margin",
+    side: "right",
+    className:
+      "pointer-events-auto absolute top-1/2 -right-3 h-10 w-2 -translate-y-1/2 cursor-e-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Adjust margin right",
+  },
+  {
+    type: "padding",
+    side: "top",
+    className:
+      "pointer-events-auto absolute -top-1 start-1/2 h-2 w-10 -translate-x-1/2 cursor-n-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Adjust padding top",
+  },
+  {
+    type: "padding",
+    side: "bottom",
+    className:
+      "pointer-events-auto absolute -bottom-1 start-1/2 h-2 w-10 -translate-x-1/2 cursor-s-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Adjust padding bottom",
+  },
+  {
+    type: "padding",
+    side: "left",
+    className:
+      "pointer-events-auto absolute top-1/2 -left-1 h-10 w-2 -translate-y-1/2 cursor-w-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Adjust padding left",
+  },
+  {
+    type: "padding",
+    side: "right",
+    className:
+      "pointer-events-auto absolute top-1/2 -end-1 h-10 w-2 -translate-y-1/2 cursor-e-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+    ariaLabel: "Adjust padding right",
+  },
+];
+
+const interactiveHandleProps = {
+  role: "button" as const,
+  tabIndex: 0,
+};
 
 export default function BlockResizer({
   selected,
@@ -20,94 +152,54 @@ export default function BlockResizer({
   startRotate,
 }: Props) {
   const t = useTranslations();
+
   if (!selected) return null;
+
   return (
-    <div className="pointer-events-none h-full w-full">
-      <div className="relative h-full w-full">
-        {/* Rotate handle (top-center, slightly offset above) */}
-        {startRotate && (
-          <div
-            className="absolute -top-7 start-1/2 -translate-x-1/2 pointer-events-auto"
-            onPointerDown={(e) => startRotate(e)}
-            title={String(t("Rotate (Shift = precise)"))}
-            role="button"
-            tabIndex={0}
-            aria-label="Rotate block"
-          >
-            <div className="group relative">
-              <div className="h-6 w-6 cursor-crosshair rounded-full bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-              <div className="pointer-events-none absolute -top-7 start-1/2 -translate-x-1/2 rounded bg-black/60 px-1 text-xs text-white opacity-0 shadow transition-opacity duration-200 delay-200 group-hover:opacity-100 group-hover:delay-0 dark:bg-white/70 dark:text-black">
-                {t("Shift = precise")}
-              </div>
+    <>
+      {startRotate && (
+        <div
+          className="absolute -top-7 start-1/2 -translate-x-1/2 pointer-events-auto"
+          onPointerDown={(event) => startRotate(event)}
+          title={String(t("Rotate (Shift = precise)"))}
+          aria-label="Rotate block"
+          {...interactiveHandleProps}
+        >
+          <div className="group relative">
+            <div className="h-6 w-6 cursor-crosshair rounded-full bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+            <div className="pointer-events-none absolute -top-7 start-1/2 -translate-x-1/2 rounded bg-black/60 px-1 text-xs text-white opacity-0 shadow transition-opacity duration-200 delay-200 group-hover:opacity-100 group-hover:delay-0 dark:bg-white/70 dark:text-black">
+              {t("Shift = precise")}
             </div>
           </div>
-        )}
-        <div onPointerDown={(e) => startResize(e, "nw")} role="button" tabIndex={0} aria-label="Resize from top-left" className="pointer-events-auto absolute -top-2 -start-2 h-6 w-6 cursor-nwse-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-        <div onPointerDown={(e) => startResize(e, "ne")} role="button" tabIndex={0} aria-label="Resize from top-right" className="pointer-events-auto absolute -top-2 -end-2 h-6 w-6 cursor-nesw-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-        <div onPointerDown={(e) => startResize(e, "sw")} role="button" tabIndex={0} aria-label="Resize from bottom-left" className="pointer-events-auto absolute -bottom-2 -start-2 h-6 w-6 cursor-nesw-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-        <div onPointerDown={(e) => startResize(e, "se")} role="button" tabIndex={0} aria-label="Resize from bottom-right" className="pointer-events-auto absolute -end-2 -bottom-2 h-6 w-6 cursor-nwse-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-        {/* Side handles */}
-        <div onPointerDown={(e) => startResize(e, "n")} role="button" tabIndex={0} aria-label="Resize from top" className="pointer-events-auto absolute -top-2 start-1/2 h-6 w-8 -translate-x-1/2 cursor-ns-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-        <div onPointerDown={(e) => startResize(e, "s")} role="button" tabIndex={0} aria-label="Resize from bottom" className="pointer-events-auto absolute -bottom-2 start-1/2 h-6 w-8 -translate-x-1/2 cursor-ns-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-        <div onPointerDown={(e) => startResize(e, "w")} role="button" tabIndex={0} aria-label="Resize from left" className="pointer-events-auto absolute top-1/2 -start-2 h-8 w-6 -translate-y-1/2 cursor-ew-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
-        <div onPointerDown={(e) => startResize(e, "e")} role="button" tabIndex={0} aria-label="Resize from right" className="pointer-events-auto absolute top-1/2 -end-2 h-8 w-6 -translate-y-1/2 cursor-ew-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary" />
+        </div>
+      )}
+      {cornerHandles.map(({ handle, className, ariaLabel }) => (
         <div
-          onPointerDown={(e) => startSpacing(e, "margin", "top")}
-          role="button"
-          tabIndex={0}
-          aria-label="Adjust margin top"
-          className="pointer-events-auto absolute -top-3 start-1/2 h-2 w-10 -translate-x-1/2 cursor-n-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          key={handle}
+          className={className}
+          onPointerDown={(event) => startResize(event, handle)}
+          aria-label={ariaLabel}
+          {...interactiveHandleProps}
         />
+      ))}
+      {edgeHandles.map(({ handle, className, ariaLabel }) => (
         <div
-          onPointerDown={(e) => startSpacing(e, "margin", "bottom")}
-          role="button"
-          tabIndex={0}
-          aria-label="Adjust margin bottom"
-          className="pointer-events-auto absolute -bottom-3 start-1/2 h-2 w-10 -translate-x-1/2 cursor-s-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          key={handle}
+          className={className}
+          onPointerDown={(event) => startResize(event, handle)}
+          aria-label={ariaLabel}
+          {...interactiveHandleProps}
         />
+      ))}
+      {spacingHandles.map(({ type, side, className, ariaLabel }) => (
         <div
-          onPointerDown={(e) => startSpacing(e, "margin", "left")}
-          role="button"
-          tabIndex={0}
-          aria-label="Adjust margin left"
-          className="pointer-events-auto absolute top-1/2 -left-3 h-10 w-2 -translate-y-1/2 cursor-w-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          key={`${type}-${side}`}
+          className={className}
+          onPointerDown={(event) => startSpacing(event, type, side)}
+          aria-label={ariaLabel}
+          {...interactiveHandleProps}
         />
-        <div
-          onPointerDown={(e) => startSpacing(e, "margin", "right")}
-          role="button"
-          tabIndex={0}
-          aria-label="Adjust margin right"
-          className="pointer-events-auto absolute top-1/2 -right-3 h-10 w-2 -translate-y-1/2 cursor-e-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-        />
-        <div
-          onPointerDown={(e) => startSpacing(e, "padding", "top")}
-          role="button"
-          tabIndex={0}
-          aria-label="Adjust padding top"
-          className="pointer-events-auto absolute -top-1 start-1/2 h-2 w-10 -translate-x-1/2 cursor-n-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-        />
-        <div
-          onPointerDown={(e) => startSpacing(e, "padding", "bottom")}
-          role="button"
-          tabIndex={0}
-          aria-label="Adjust padding bottom"
-          className="pointer-events-auto absolute -bottom-1 start-1/2 h-2 w-10 -translate-x-1/2 cursor-s-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-        />
-        <div
-          onPointerDown={(e) => startSpacing(e, "padding", "left")}
-          role="button"
-          tabIndex={0}
-          aria-label="Adjust padding left"
-          className="pointer-events-auto absolute top-1/2 -left-1 h-10 w-2 -translate-y-1/2 cursor-w-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-        />
-        <div
-          onPointerDown={(e) => startSpacing(e, "padding", "right")}
-          role="button"
-          tabIndex={0}
-          aria-label="Adjust padding right"
-          className="pointer-events-auto absolute top-1/2 -end-1 h-10 w-2 -translate-y-1/2 cursor-e-resize bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-        />
-      </div>
-    </div>
+      ))}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- clamp and expose the Progress bar width as an inline style for predictable rendering
- refactor BlockResizer handles into mapped fragments so pointer events fire on the expected elements

## Testing
- pnpm --filter @acme/ui exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --coverage=false --runTestsByPath ./__tests__/Progress.test.tsx ./src/components/cms/page-builder/__tests__/BlockResizer.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc28a8bda0832fa7cf7fbf058965fb