### PR TITLE
Add accessible drawer descriptions and stub CMS fetch

### DIFF
--- a/packages/ui/src/components/cms/page-builder/CMSPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/CMSPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { Drawer, DrawerContent, DrawerTitle, DrawerPortal } from "../../atoms/primitives/drawer";
+import { Drawer, DrawerContent, DrawerDescription, DrawerTitle, DrawerPortal } from "../../atoms/primitives/drawer";
 import { Button, Input } from "../../atoms/shadcn";
 import { OverlayScrim } from "../../atoms";
 import type { PageComponent } from "@acme/types";
@@ -53,61 +53,64 @@ export default function CMSPanel({ open, onOpenChange, components, selectedIds: 
       <DrawerPortal>
         <OverlayScrim />
         <DrawerContent side="right" width="w-96" className="flex h-full flex-col p-0">
-        <div className="px-4 py-3">
-          {/* i18n-exempt */}
-          <DrawerTitle>{t("CMS Connections")}</DrawerTitle>
-        </div>
-        <div className="flex flex-1 flex-col gap-3 p-3 text-sm">
-          {/* i18n-exempt */}
-          <Input placeholder={t("Search datasets…")} value={q} onChange={(e) => setQ(e.target.value)} />
-          <div className="text-xs text-muted-foreground">{t(`${filtered.length} dataset${filtered.length === 1 ? "" : "s"}`)}</div>
-          <div className="flex-1 overflow-auto">
-            {filtered.length === 0 && (
-              // i18n-exempt — editor-only hint
-              /* i18n-exempt */
-              <div className="p-2 text-muted-foreground">{t("No datasets on this page. Insert a Dataset block to connect elements.")}</div>
-            )}
-            <ul className="space-y-2">
-              {filtered.map((d) => {
-                const raw = (d as Record<string, unknown>).dataset as Record<string, unknown> | undefined;
-                const cfg = {
-                  source: raw && typeof raw.source === "string" ? raw.source : undefined,
-                  mode: raw && typeof raw.mode === "string" ? raw.mode : undefined,
-                  maxItems: raw && typeof raw.maxItems === "number" ? raw.maxItems : undefined,
-                } as { source?: string; mode?: string; maxItems?: number };
-                return (
-                  <li key={d.id} className="rounded border p-2">
-                    <div className="flex items-center justify-between gap-2">
-                      <div className="min-w-0">
-                        <div className="truncate font-medium">{typeof (d as Record<string, unknown>).name === "string" ? (d as Record<string, unknown>).name as string : d.type}</div>
-                        <div className="truncate text-xs text-muted-foreground">
+          <div className="px-4 py-3">
+            {/* i18n-exempt */}
+            <DrawerTitle>{t("CMS Connections")}</DrawerTitle>
+            <DrawerDescription className="sr-only">
+              {t("Browse datasets on the current page and connect them to components.")}
+            </DrawerDescription>
+          </div>
+          <div className="flex flex-1 flex-col gap-3 p-3 text-sm">
+            {/* i18n-exempt */}
+            <Input placeholder={t("Search datasets…")} value={q} onChange={(e) => setQ(e.target.value)} />
+            <div className="text-xs text-muted-foreground">{t(`${filtered.length} dataset${filtered.length === 1 ? "" : "s"}`)}</div>
+            <div className="flex-1 overflow-auto">
+              {filtered.length === 0 && (
+                // i18n-exempt — editor-only hint
+                /* i18n-exempt */
+                <div className="p-2 text-muted-foreground">{t("No datasets on this page. Insert a Dataset block to connect elements.")}</div>
+              )}
+              <ul className="space-y-2">
+                {filtered.map((d) => {
+                  const raw = (d as Record<string, unknown>).dataset as Record<string, unknown> | undefined;
+                  const cfg = {
+                    source: raw && typeof raw.source === "string" ? raw.source : undefined,
+                    mode: raw && typeof raw.mode === "string" ? raw.mode : undefined,
+                    maxItems: raw && typeof raw.maxItems === "number" ? raw.maxItems : undefined,
+                  } as { source?: string; mode?: string; maxItems?: number };
+                  return (
+                    <li key={d.id} className="rounded border p-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="truncate font-medium">{typeof (d as Record<string, unknown>).name === "string" ? (d as Record<string, unknown>).name as string : d.type}</div>
+                          <div className="truncate text-xs text-muted-foreground">
+                            {/* i18n-exempt */}
+                            {t("Source:")} {cfg.source || "—"}
+                            {/* i18n-exempt */}
+                            {" · "}
+                            {/* i18n-exempt */}
+                            {t("Mode:")} {cfg.mode || "read"}
+                            {/* i18n-exempt */}
+                            {" · "}
+                            {/* i18n-exempt */}
+                            {t("Max items:")} {cfg.maxItems ?? "—"}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-1">
                           {/* i18n-exempt */}
-                          {t("Source:")} {cfg.source || "—"} 
-                          {/* i18n-exempt */}
-                          {" · "}
-                          {/* i18n-exempt */}
-                          {t("Mode:")} {cfg.mode || "read"} 
-                          {/* i18n-exempt */}
-                          {" · "}
-                          {/* i18n-exempt */}
-                          {t("Max items:")} {cfg.maxItems ?? "—"}
+                          <Button variant="outline" className="h-7 px-2" onClick={() => onSelectIds([d.id])}>{t("Select")}</Button>
                         </div>
                       </div>
-                      <div className="flex items-center gap-1">
-                        {/* i18n-exempt */}
-                        <Button variant="outline" className="h-7 px-2" onClick={() => onSelectIds([d.id])}>{t("Select")}</Button>
-                      </div>
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {/* i18n-exempt */}
+              {t("Tip: Select a Dataset block, then use the Inspector → CMS tab to configure connections and filters.")}
+            </div>
           </div>
-          <div className="text-xs text-muted-foreground">
-            {/* i18n-exempt */}
-            {t("Tip: Select a Dataset block, then use the Inspector → CMS tab to configure connections and filters.")}
-          </div>
-        </div>
         </DrawerContent>
       </DrawerPortal>
     </Drawer>

--- a/packages/ui/src/components/cms/page-builder/__tests__/drawer.visual.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/drawer.visual.test.tsx
@@ -5,6 +5,30 @@ import CommentsDrawer from "../CommentsDrawer";
 import PagesPanel from "../PagesPanel";
 import CMSPanel from "../CMSPanel";
 
+let fetchMock: jest.SpyInstance<ReturnType<typeof fetch>, Parameters<typeof fetch>>;
+
+beforeAll(() => {
+  fetchMock = jest.spyOn(globalThis, "fetch").mockImplementation(async (...args) => {
+    const [, init] = args;
+    const method = init?.method?.toUpperCase() ?? "GET";
+    if (method === "GET") {
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(null, { status: 204 });
+  });
+});
+
+afterEach(() => {
+  fetchMock.mockClear();
+});
+
+afterAll(() => {
+  fetchMock.mockRestore();
+});
+
 describe("CMS drawers surfaces", () => {
   it("CommentsDrawer uses panel surface and right border", async () => {
     render(

--- a/packages/ui/src/components/cms/page-builder/pages-panel/PagesPanel.tsx
+++ b/packages/ui/src/components/cms/page-builder/pages-panel/PagesPanel.tsx
@@ -2,7 +2,7 @@
 // i18n-exempt — editor-only Pages panel; copy pending i18n wiring
 
 import React, { useMemo } from "react";
-import { Drawer, DrawerContent, DrawerTitle, DrawerPortal } from "../../../atoms/primitives/drawer";
+import { Drawer, DrawerContent, DrawerDescription, DrawerTitle, DrawerPortal } from "../../../atoms/primitives/drawer";
 import { OverlayScrim } from "../../../atoms";
 import { Sidebar } from "../../../atoms/primitives/Sidebar";
 import { Stack } from "../../../atoms/primitives/Stack";
@@ -10,6 +10,9 @@ import { deriveShopFromPath } from "./utils";
 import { usePagesState } from "./usePagesState";
 import { PagesList } from "./PagesList";
 import { PageSettings } from "./PageSettings";
+
+/* i18n-exempt */
+const t = (s: string) => s;
 
 export default function PagesPanel({ open, onOpenChange, shop: shopProp = null }: { open: boolean; onOpenChange: (v: boolean) => void; shop?: string | null }) {
   const shop = useMemo(() => shopProp ?? deriveShopFromPath() ?? "", [shopProp]);
@@ -21,7 +24,10 @@ export default function PagesPanel({ open, onOpenChange, shop: shopProp = null }
         <OverlayScrim />
         <DrawerContent side="left" width="w-[42rem]" className="flex h-full flex-col p-0">
           <div className="flex-none px-4 py-3">
-            <DrawerTitle>Pages</DrawerTitle>
+            <DrawerTitle>{t("Pages")}</DrawerTitle>
+            <DrawerDescription className="sr-only">
+              {t("Manage the site pages list and configure the selected page.")}
+            </DrawerDescription>
           </div>
           <Sidebar sideWidth="w-72" gap={0} className="flex-1 min-h-0">
             <PagesList


### PR DESCRIPTION
## Summary
- add sr-only DrawerDescription copy for the CMS and Pages drawers to satisfy Radix accessibility checks
- reuse the existing editor-only `t` helper for the new copy and keep the panels i18n-exempt
- stub global fetch in the CMS drawer visual test to avoid MSW unhandled request noise during renders

## Testing
- pnpm --filter @acme/ui test:quick -- --testPathPattern drawer.visual.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc2a4a9a80832f87fb74eae96d1642