### PR TITLE
Fix textarea label layout and margins

### DIFF
--- a/packages/ui/src/components/atoms/primitives/textarea.tsx
+++ b/packages/ui/src/components/atoms/primitives/textarea.tsx
@@ -3,7 +3,6 @@
 
 import * as React from "react";
 import { cn } from "../../../utils/style";
-import { Stack } from "./Stack";
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -69,10 +68,16 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     /* ------------------------------------------------------------------
      * Render
      * ------------------------------------------------------------------ */
+    const wrapperClasses = cn(
+      "flex flex-col gap-1",
+      floatingLabel && "relative",
+      wrapperClassName
+    );
+
     return (
-      <Stack gap={1} className={wrapperClassName}>
+      <div className={wrapperClasses}>
         {floatingLabel ? (
-          <div className="relative">
+          <>
             <textarea
               id={textareaId}
               ref={ref}
@@ -93,11 +98,14 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
                 {label}
               </label>
             )}
-          </div>
+          </>
         ) : (
           <>
             {label && (
-              <label htmlFor={textareaId} className="block text-sm font-medium"> {/* i18n-exempt -- DS-1234 [ttl=2025-11-30] */}
+              <label
+                htmlFor={textareaId}
+                className="mb-1 block text-sm font-medium"
+              > {/* i18n-exempt -- DS-1234 [ttl=2025-11-30] */}
                 {label}
               </label>
             )}
@@ -117,7 +125,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             {error}
           </p>
         )}
-      </Stack>
+      </div>
     );
   }
 );


### PR DESCRIPTION
## Summary
- add a wrapper class helper to the textarea component so the outer element handles layout without the Stack helper
- update the standard label to include the expected margin utility
- flatten the floating-label structure so the textarea and label remain siblings while preserving absolute positioning

## Testing
- pnpm --filter @acme/ui exec jest --runInBand --config ./jest.config.cjs --testPathPattern textarea.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dc2c180b90832fb4ceb12d20a8b10d