### PR TITLE
Add dialog descriptions for preset manager modals

### DIFF
--- a/packages/ui/src/components/cms/page-builder/style-panel/PresetManager.tsx
+++ b/packages/ui/src/components/cms/page-builder/style-panel/PresetManager.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useState } from "react";
 import { useTranslations } from "@acme/i18n";
-import { Button, Textarea, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../../atoms/shadcn";
+import {
+  Button,
+  Textarea,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../../atoms/shadcn";
 import type { StyleOverrides } from "@acme/types/style/StyleOverrides";
 import type { CustomPreset } from "../style/customPresets";
 
@@ -168,6 +177,9 @@ export default function PresetManager({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t("cms.style.customPresets.exportTitle")}</DialogTitle>
+            <DialogDescription className="text-sm text-muted-foreground">
+              {t("cms.style.customPresets.exportAllAria")}
+            </DialogDescription>
           </DialogHeader>
           <Textarea value={exportText} readOnly rows={10} />
           <DialogFooter>
@@ -186,6 +198,9 @@ export default function PresetManager({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t("cms.style.customPresets.importTitle")}</DialogTitle>
+            <DialogDescription className="text-sm text-muted-foreground">
+              {t("cms.style.customPresets.importPlaceholder")}
+            </DialogDescription>
           </DialogHeader>
           <Textarea
             value={importText}


### PR DESCRIPTION
## Summary
- add dialog descriptions to the preset export and import modals so the Radix dialog content always has an accessible description

## Testing
- JEST_DISABLE_COVERAGE_THRESHOLD=1 pnpm exec jest --runInBand --detectOpenHandles --config ./jest.config.cjs --testPathPattern PresetManager.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dc2c7613e8832fa69847a4f8f07aff