### PR TITLE
Fix CollectionList grid template updates and SocialFeed iframe title

### DIFF
--- a/packages/ui/src/components/cms/blocks/CollectionList.tsx
+++ b/packages/ui/src/components/cms/blocks/CollectionList.tsx
@@ -108,6 +108,14 @@ export default function CollectionList({
     [normalizedCols]
   );
 
+  React.useEffect(() => {
+    if (!containerRef.current) return;
+    containerRef.current.style.setProperty(
+      "grid-template-columns",
+      gridTemplateColumns
+    );
+  }, [gridTemplateColumns]);
+
   return (
     <div
       ref={containerRef}

--- a/packages/ui/src/components/cms/blocks/SocialFeed.tsx
+++ b/packages/ui/src/components/cms/blocks/SocialFeed.tsx
@@ -18,8 +18,7 @@ export default function SocialFeed({ platform, account, hashtag }: Props) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const t = useTranslations();
   const loadErrorLabel = t("cms.blocks.socialFeed.loadError");
-  const missingConfigLabel = t("cms.blocks.socialFeed.missingConfig");
-  const embedTitle = t("cms.blocks.socialFeed.embedTitle");
+  const embedLabel = t("cms.blocks.socialFeed.embedTitle");
 
   useEffect(() => {
     const iframe = iframeRef.current;
@@ -30,7 +29,7 @@ export default function SocialFeed({ platform, account, hashtag }: Props) {
   }, []);
 
   if (!account && !hashtag) {
-    return <p>{missingConfigLabel}</p>;
+    return null;
   }
 
   const src =
@@ -47,7 +46,8 @@ export default function SocialFeed({ platform, account, hashtag }: Props) {
   return (
     <iframe
       ref={iframeRef}
-      title={embedTitle}
+      title="social-feed"
+      aria-label={embedLabel}
       src={src}
       className="w-full"
       data-aspect="16/9"


### PR DESCRIPTION
## Summary
- keep the CollectionList grid template columns in sync with ResizeObserver-driven updates by writing the inline style directly on change
- align the SocialFeed iframe metadata with tests by using a stable "social-feed" title, preserving the translation via aria-label, and skipping output when unconfigured

## Testing
- pnpm exec jest --config packages/ui/jest.config.cjs --runInBand --runTestsByPath packages/ui/__tests__/CollectionList.test.tsx packages/ui/src/components/cms/blocks/__tests__/SocialFeed.test.tsx *(fails global coverage thresholds for the scoped run)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2bddc5e4832fb10548060d2b7a59