### PR TITLE
Silence ComponentPreview test error logs

### DIFF
--- a/packages/ui/__tests__/ComponentPreview.import-fail.test.tsx
+++ b/packages/ui/__tests__/ComponentPreview.import-fail.test.tsx
@@ -1,19 +1,43 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import ComponentPreview from "../src/components/ComponentPreview";
 import type { UpgradeComponent } from "@acme/types";
 
 describe("ComponentPreview import failures", () => {
   it("renders nothing and does not crash when dynamic import fails", async () => {
-    // No __UPGRADE_MOCKS__ set so both dynamic imports will fail & be caught
-    const component: UpgradeComponent = {
-      componentName: "Missing",
-      file: "Missing.tsx",
-    } as UpgradeComponent;
+    const consoleErrorMock = console.error as jest.MockedFunction<typeof console.error>;
+    const originalConsoleImpl = consoleErrorMock.getMockImplementation();
+    const initialCallCount = consoleErrorMock.mock.calls.length;
+    consoleErrorMock.mockImplementation(() => {});
 
-    const { container } = render(<ComponentPreview component={component} />);
-    // Nothing rendered (no mock provided, old/new both unavailable)
-    expect(container.querySelector("button")).toBeNull();
+    try {
+      // No __UPGRADE_MOCKS__ set so both dynamic imports will fail & be caught
+      const component: UpgradeComponent = {
+        componentName: "Missing",
+        file: "Missing.tsx",
+      } as UpgradeComponent;
+
+      const { container } = render(<ComponentPreview component={component} />);
+      // Nothing rendered (no mock provided, old/new both unavailable)
+      expect(container.querySelector("button")).toBeNull();
+
+      await waitFor(
+        () => {
+          expect(consoleErrorMock.mock.calls.length).toBeGreaterThan(initialCallCount);
+        },
+        { timeout: 3000 },
+      );
+
+      const newCalls = consoleErrorMock.mock.calls.slice(initialCallCount);
+
+      const matchingCall = newCalls.find(
+        ([first, second]) => first === "Failed to load component" && second === "Missing",
+      );
+
+      expect(matchingCall).toBeDefined();
+    } finally {
+      consoleErrorMock.mockImplementation(originalConsoleImpl ?? (() => {}));
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- intercept `console.error` in ComponentPreview error-path tests to avoid noisy output while still asserting the logged content
- wait for async error handling so expectations are stable across all ComponentPreview suites

## Testing
- pnpm --filter @acme/ui exec jest --runInBand --collectCoverage=false packages/ui/src/components/__tests__/ComponentPreview.test.tsx packages/ui/__tests__/ComponentPreview.modes.test.tsx packages/ui/__tests__/ComponentPreview.import-fail.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc32494ac4832fa4db45da658de586