### PR TITLE
Silence expected console errors in ComponentPreview test

### DIFF
--- a/packages/ui/__tests__/ComponentPreview.modes.test.tsx
+++ b/packages/ui/__tests__/ComponentPreview.modes.test.tsx
@@ -55,6 +55,10 @@ describe("ComponentPreview advanced modes and error handling", () => {
   });
 
   it("renders error boundary fallback when component throws", async () => {
+    const consoleErrorMock = jest.mocked(console.error);
+    const originalConsoleError = consoleErrorMock.getMockImplementation();
+    consoleErrorMock.mockImplementation(() => {});
+
     const Thrower = () => {
       throw new Error("boom");
     };
@@ -67,11 +71,19 @@ describe("ComponentPreview advanced modes and error handling", () => {
       file: "Boom.tsx",
     } as UpgradeComponent;
 
-    render(<ComponentPreview component={component} />);
+    try {
+      render(<ComponentPreview component={component} />);
 
-    expect(
-      await screen.findByText("Failed to render preview")
-    ).toBeInTheDocument();
+      expect(
+        await screen.findByText("Failed to render preview")
+      ).toBeInTheDocument();
+    } finally {
+      if (originalConsoleError) {
+        consoleErrorMock.mockImplementation(originalConsoleError);
+      } else {
+        consoleErrorMock.mockRestore();
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- wrap the ComponentPreview error boundary test in a local console.error mock to suppress expected error noise

## Testing
- pnpm exec jest --config packages/ui/jest.config.cjs --runInBand --testPathPattern ComponentPreview.modes.test.tsx --coverage=false *(fails: repository enforces global coverage thresholds for partial runs)*

------
https://chatgpt.com/codex/tasks/task_e_68dc31471a50832f8845ea985b4ac2cd