### PR TITLE
Fix ImageSourcePanel test translations mock

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/ImageSourcePanel.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/ImageSourcePanel.test.tsx
@@ -1,12 +1,14 @@
 import "../../../../../../../test/resetNextMocks";
 import { fireEvent, render, screen } from "@testing-library/react";
 import ImageSourcePanel from "../ImageSourcePanel";
-const useTranslationsMock = jest.fn(() => (key: string) => key);
 
 jest.mock("@acme/i18n", () => ({
   __esModule: true,
-  useTranslations: () => useTranslationsMock(),
+  useTranslations: jest.fn(() => (key: string) => key),
 }));
+
+const { useTranslations } = jest.requireMock<typeof import("@acme/i18n")>("@acme/i18n");
+const useTranslationsMock = useTranslations as jest.MockedFunction<typeof useTranslations>;
 
 const probe = jest.fn();
 let probeState = { loading: false, error: "", valid: true };
@@ -27,6 +29,8 @@ jest.mock("../ImagePicker", () => ({
 
 describe("ImageSourcePanel", () => {
   beforeEach(() => {
+    useTranslationsMock.mockReset();
+    useTranslationsMock.mockImplementation(() => (key: string) => key);
     probe.mockClear();
     probeState = { loading: false, error: "", valid: true };
   });


### PR DESCRIPTION
## Summary
- update the ImageSourcePanel test to mock `useTranslations` directly instead of spying on the exported getter
- reset the translation mock before each test to keep the identity translator stub stable

## Testing
- pnpm --filter @acme/ui test -- ImageSourcePanel.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc3268aca0832fb14d16cd7c8fc616