### PR TITLE
Fix drawer mocks to include description

### DIFF
--- a/packages/ui/src/components/cms/page-builder/__tests__/PagesPanel.crud.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/PagesPanel.crud.test.tsx
@@ -37,6 +37,7 @@ jest.mock("../../../atoms/primitives/drawer", () => ({
   DrawerPortal: ({ children }: any) => <div>{children}</div>,
   DrawerContent: ({ children }: any) => <div role="dialog">{children}</div>,
   DrawerTitle: ({ children }: any) => <div>{children}</div>,
+  DrawerDescription: ({ children }: any) => <div>{children}</div>,
 }));
 
 // Mock OverlayScrim from atoms to avoid Radix Dialog overlay usage

--- a/packages/ui/src/components/cms/page-builder/__tests__/PagesPanel.notify.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/PagesPanel.notify.test.tsx
@@ -9,6 +9,7 @@ jest.mock("../../../atoms/primitives/drawer", () => ({
   DrawerPortal: ({ children }: any) => <div>{children}</div>,
   DrawerContent: ({ children }: any) => <div role="dialog">{children}</div>,
   DrawerTitle: ({ children }: any) => <div>{children}</div>,
+  DrawerDescription: ({ children }: any) => <div>{children}</div>,
 }));
 jest.mock("../../../atoms", () => ({ __esModule: true, OverlayScrim: () => null }));
 

--- a/packages/ui/src/components/cms/page-builder/__tests__/PagesPanel.search.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/PagesPanel.search.test.tsx
@@ -8,6 +8,7 @@ jest.mock("../../../atoms/primitives/drawer", () => ({
   DrawerPortal: ({ children }: any) => <div>{children}</div>,
   DrawerContent: ({ children }: any) => <div role="dialog">{children}</div>,
   DrawerTitle: ({ children }: any) => <div>{children}</div>,
+  DrawerDescription: ({ children }: any) => <div>{children}</div>,
 }));
 jest.mock("../../../atoms", () => ({ __esModule: true, OverlayScrim: () => null }));
 

--- a/packages/ui/src/components/cms/page-builder/__tests__/PagesPanel.successPaths.test.tsx
+++ b/packages/ui/src/components/cms/page-builder/__tests__/PagesPanel.successPaths.test.tsx
@@ -10,6 +10,7 @@ jest.mock("../../../atoms/primitives/drawer", () => ({
   DrawerPortal: ({ children }: any) => <div>{children}</div>,
   DrawerContent: ({ children }: any) => <div role="dialog">{children}</div>,
   DrawerTitle: ({ children }: any) => <div>{children}</div>,
+  DrawerDescription: ({ children }: any) => <div>{children}</div>,
 }));
 jest.mock("../../../atoms", () => ({ __esModule: true, OverlayScrim: () => null }));
 


### PR DESCRIPTION
## Summary
- add DrawerDescription stubs to the PagesPanel drawer mocks so React receives a valid element type

## Testing
- pnpm --filter @acme/ui exec jest --runInBand --config jest.config.cjs --runTestsByPath src/components/cms/page-builder/__tests__/PagesPanel.successPaths.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dc3256b9ec832f840573272f096787