### PR TITLE
Fix @acme/lib tsconfig.test.json for Jest ESM support

### DIFF
--- a/packages/lib/tsconfig.test.json
+++ b/packages/lib/tsconfig.test.json
@@ -1,9 +1,19 @@
 {
-  "extends": "./tsconfig.test.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "../../..",
-    "noEmit": true
+    "types": ["jest", "node"],
+    "composite": true,
+    "declaration": true,
+    "declarationMap": false,
+    "declarationDir": ".ts-jest",
+    "noEmit": false,
+    "noEmitOnError": false,
+    "rootDir": ".",
+    "outDir": ".ts-jest",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true
   },
-  "include": ["../**/*.ts", "../**/*.tsx"],
-  "exclude": ["../**/__tests__/**"]
+  "include": ["src/**/*", "__tests__/**/*"],
+  "exclude": []
 }


### PR DESCRIPTION
## Summary
- correct the @acme/lib test tsconfig to extend the package config and emit into a ts-jest scratch directory
- configure CommonJS module settings so ts-jest transpiles ESM sources for Jest
- include jest/node type declarations to support the test environment

## Testing
- pnpm --filter @acme/lib exec jest --config ../../jest.config.cjs src/tryon/__tests__/index.test.ts --runInBand --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68dcd55db394832f9b4033b31bfa8f00