### PR TITLE
Fix cart rental payload and align safe FS import

### DIFF
--- a/packages/platform-core/src/cartApi.ts
+++ b/packages/platform-core/src/cartApi.ts
@@ -119,7 +119,7 @@ export async function POST(req: NextRequest) {
   // Only pass `rental` when defined to avoid an extra undefined arg
   const updated = await (typeof rental === "undefined"
     ? incrementQty(cartId, sku, qty, size)
-    : incrementQty(cartId, sku, qty, size, { ...rental, sku: sku.id }));
+    : incrementQty(cartId, sku, qty, size, rental));
   const res = NextResponse.json({ ok: true, cart: updated });
   res.headers.set("Set-Cookie", asSetCookieHeader(encodeCartCookie(cartId)));
   return res;

--- a/packages/platform-core/src/utils/safeFs.ts
+++ b/packages/platform-core/src/utils/safeFs.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from "node:fs";
+import { promises as fs } from "fs";
 import * as path from "node:path";
 import { DATA_ROOT } from "../dataRoot";
 import { validateShopName } from "../shops/index";


### PR DESCRIPTION
## Summary
- import `fs.promises` from the standard "fs" entry so repository helpers respect Jest mocks
- forward cart rental metadata unchanged when incrementing quantities to keep store input intact

## Testing
- `pnpm --filter @acme/platform-core test -- --runTestsByPath packages/platform-core/src/repositories/__tests__/settings.server.test.ts` *(hangs in container; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68dcceea5ac8832fae58948257157d07