### PR TITLE
Ensure loadThemeTokens respects browser globals

### DIFF
--- a/packages/platform-core/src/themeTokens/index.ts
+++ b/packages/platform-core/src/themeTokens/index.ts
@@ -125,7 +125,10 @@ export async function loadThemeTokensBrowser(theme: string): Promise<TokenMap> {
 }
 
 export async function loadThemeTokens(theme: string): Promise<TokenMap> {
-  if (typeof window === "undefined") {
+  const hasWindow =
+    typeof globalThis !== "undefined" &&
+    typeof (globalThis as { window?: unknown }).window !== "undefined";
+  if (!hasWindow) {
     return loadThemeTokensNode(theme);
   }
   return loadThemeTokensBrowser(theme);


### PR DESCRIPTION
## Summary
- guard browser detection against environments where only globalThis.window exists
- continue delegating to the Node loader when no browser globals are available

## Testing
- pnpm --filter @acme/platform-core test -- --testPathPattern themeTokens.test.ts *(fails: Jest global coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68dccf1c9ff4832f9d0bf80955632b62