### PR TITLE
Use fs promises alias in safe filesystem helper

### DIFF
--- a/packages/platform-core/src/utils/safeFs.ts
+++ b/packages/platform-core/src/utils/safeFs.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from "node:fs";
+import { promises as fs } from "fs";
 import * as path from "node:path";
 import { DATA_ROOT } from "../dataRoot";
 import { validateShopName } from "../shops/index";


### PR DESCRIPTION
## Summary
- import the filesystem promises API from "fs" so existing Jest mocks intercept `readFromShop`

## Testing
- pnpm --filter @acme/platform-machine test -- --testPathPattern shops.server.test.ts *(fails: global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd6631f30832f8a294c5eb00e412f