### PR TITLE
Ensure @acme/lib tests use the CJS ts-jest preset

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -78,9 +78,10 @@ const coverageThreshold = JSON.parse(
 
 const forceCjs = process.env.JEST_FORCE_CJS === "1";
 const isPlatformCorePackage = /packages\/platform-core$/.test(process.cwd());
+const isLibPackage = /packages\/lib$/.test(process.cwd());
 // Some Next.js app packages exercise pages/components that are more stable under CJS in Jest
 const isShopBcdApp = /apps\/shop-bcd$/.test(process.cwd());
-const useCjsPreset = forceCjs || isPlatformCorePackage || isShopBcdApp;
+const useCjsPreset = forceCjs || isPlatformCorePackage || isShopBcdApp || isLibPackage;
 const preset = useCjsPreset ? "ts-jest" : "ts-jest/presets/default-esm";
 const useESM = !useCjsPreset;
 


### PR DESCRIPTION
## Summary
- force the @acme/lib workspace to reuse the CommonJS ts-jest preset so its TypeScript sources are transformed before execution

## Testing
- pnpm --filter @acme/lib test -- --runTestsByPath src/tryon/__tests__/cloudflare.test.ts *(fails because the suite does not meet the configured global coverage thresholds, but the tests themselves pass)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd7211ef8832fae4ed2ce577e60a8