### PR TITLE
Fix numeric style handling in boxProps

### DIFF
--- a/packages/ui/src/utils/style/boxProps.ts
+++ b/packages/ui/src/utils/style/boxProps.ts
@@ -13,8 +13,6 @@ export function boxProps({ width, height, padding, margin }: BoxOptions) {
   if (width !== undefined) {
     if (typeof width === "string" && (width.startsWith("w-") || width.includes(":w-"))) {
       classes.push(width);
-    } else if (typeof width === "number") {
-      style.width = `${width}px`;
     } else {
       style.width = width;
     }
@@ -23,8 +21,6 @@ export function boxProps({ width, height, padding, margin }: BoxOptions) {
   if (height !== undefined) {
     if (typeof height === "string" && (height.startsWith("h-") || height.includes(":h-"))) {
       classes.push(height);
-    } else if (typeof height === "number") {
-      style.height = `${height}px`;
     } else {
       style.height = height;
     }


### PR DESCRIPTION
## Summary
- update boxProps to keep numeric width and height values as numbers so React applies px units automatically

## Testing
- pnpm --filter @acme/ui test:quick -- --runTestsByPath packages/ui/src/utils/style/__tests__/boxProps.test.ts (fails: package enforces global coverage thresholds when coverage is collected)


------
https://chatgpt.com/codex/tasks/task_e_68dcde1a1cac832fa8285d9b608f98f2