### PR TITLE
test(lib): ensure full coverage

### DIFF
--- a/packages/lib/src/__tests__/__fixtures__/openai-function.cjs
+++ b/packages/lib/src/__tests__/__fixtures__/openai-function.cjs
@@ -1,0 +1,10 @@
+const globalState = globalThis.__OPENAI_FUNCTION_EXPORT__ || (globalThis.__OPENAI_FUNCTION_EXPORT__ = {});
+
+function OpenAI(init) {
+  if (typeof globalState.impl === "function") {
+    return globalState.impl(init);
+  }
+  throw new Error("OpenAI implementation not set");
+}
+
+module.exports = OpenAI;

--- a/packages/lib/src/__tests__/generateMeta.openai.edge-cases.test.ts
+++ b/packages/lib/src/__tests__/generateMeta.openai.edge-cases.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, afterEach, expect, jest } from "@jest/globals";
+
+jest.mock("path", () => ({
+  join: jest.fn((...parts: string[]) => parts.join("/")),
+  dirname: jest.fn((p: string) => p.split("/").slice(0, -1).join("/")),
+}));
+
+import * as path from "path";
+
+const product = { id: "edge", title: "Edge", description: "Case" };
+const writeMock = jest.fn();
+const mkdirMock = jest.fn();
+const fetchMock = jest.fn();
+
+(global as { fetch: typeof fetch }).fetch = fetchMock;
+
+jest.mock("fs", () => ({
+  promises: {
+    mkdir: mkdirMock,
+    writeFile: writeMock,
+  },
+}));
+
+describe("generateMeta edge cases", () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    writeMock.mockReset();
+    mkdirMock.mockReset();
+    fetchMock.mockReset();
+    (path.join as jest.Mock).mockClear();
+    (path.dirname as jest.Mock).mockClear();
+    jest.resetModules();
+  });
+
+  it("handles responses that omit content entries", async () => {
+    process.env.NODE_ENV = "production";
+    const responsesCreate = jest.fn().mockResolvedValue({ output: [] });
+    const imagesGenerate = jest.fn().mockResolvedValue({ data: [{ b64_json: "" }] });
+    const OpenAI = jest.fn().mockImplementation(() => ({
+      responses: { create: responsesCreate },
+      images: { generate: imagesGenerate },
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const envMock = { OPENAI_API_KEY: "key" };
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
+      jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), {
+        virtual: true,
+      });
+      const { generateMeta } = await import("../generateMeta");
+      const meta = await generateMeta(product);
+
+      expect(meta).toEqual({
+        title: product.title,
+        description: product.description,
+        alt: product.title,
+        image: `/og/${product.id}.png`,
+      });
+      expect(responsesCreate).toHaveBeenCalledTimes(1);
+      expect(imagesGenerate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("ignores non-string content payloads", async () => {
+    process.env.NODE_ENV = "production";
+    const responsesCreate = jest.fn().mockResolvedValue({
+      output: [
+        {
+          content: [
+            {
+              text: { title: "Ignored" },
+            },
+          ],
+        },
+      ],
+    });
+    const imagesGenerate = jest.fn().mockResolvedValue({ data: [{ b64_json: "" }] });
+    const OpenAI = jest.fn().mockImplementation(() => ({
+      responses: { create: responsesCreate },
+      images: { generate: imagesGenerate },
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const envMock = { OPENAI_API_KEY: "key" };
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
+      jest.doMock("openai", () => ({ __esModule: true, default: OpenAI }), {
+        virtual: true,
+      });
+      const { generateMeta } = await import("../generateMeta");
+      const meta = await generateMeta(product);
+
+      expect(meta).toEqual({
+        title: product.title,
+        description: product.description,
+        alt: product.title,
+        image: `/og/${product.id}.png`,
+      });
+      expect(responsesCreate).toHaveBeenCalledTimes(1);
+      expect(imagesGenerate).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+

--- a/packages/lib/src/__tests__/generateMeta.openai.function-export.test.ts
+++ b/packages/lib/src/__tests__/generateMeta.openai.function-export.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, afterEach, expect, jest } from "@jest/globals";
+
+jest.mock("path", () => ({
+  join: jest.fn((...parts: string[]) => parts.join("/")),
+  dirname: jest.fn((p: string) => p.split("/").slice(0, -1).join("/")),
+}));
+
+import * as path from "path";
+
+const product = { id: "abc-123", title: "Title", description: "Description" };
+const writeMock = jest.fn();
+const mkdirMock = jest.fn();
+const fetchMock = jest.fn();
+
+(global as unknown as { fetch: typeof fetch }).fetch = fetchMock;
+
+jest.mock("fs", () => ({
+  promises: {
+    mkdir: mkdirMock,
+    writeFile: writeMock,
+  },
+}));
+
+describe("generateMeta when OpenAI module is a function export", () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    delete (globalThis as { __OPENAI_IMPORT_ERROR__?: boolean }).__OPENAI_IMPORT_ERROR__;
+    writeMock.mockReset();
+    mkdirMock.mockReset();
+    fetchMock.mockReset();
+    (path.join as jest.Mock).mockClear();
+    (path.dirname as jest.Mock).mockClear();
+    delete (globalThis as { __OPENAI_FUNCTION_EXPORT__?: unknown }).__OPENAI_FUNCTION_EXPORT__;
+    jest.resetModules();
+  });
+
+  it("parses text content objects and writes empty image buffers", async () => {
+    process.env.NODE_ENV = "production";
+
+    const responsesCreate = jest.fn().mockResolvedValue({
+      output: [
+        {
+          content: [
+            {
+              text: JSON.stringify({
+                description: "AI description",
+              }),
+            },
+          ],
+        },
+      ],
+    });
+    const imagesGenerate = jest.fn().mockResolvedValue({ data: [{}] });
+
+    const OpenAIImpl = jest.fn().mockImplementation(() => ({
+      responses: { create: responsesCreate },
+      images: { generate: imagesGenerate },
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const envMock = { OPENAI_API_KEY: "key" };
+      jest.doMock("@acme/config/env/core", () => ({ coreEnv: envMock }));
+      const actualTslib = jest.requireActual("tslib");
+      jest.doMock(
+        "tslib",
+        () => ({
+          ...actualTslib,
+          __importStar: (mod: unknown) => mod,
+        }),
+        { virtual: true },
+      );
+      (globalThis as { __OPENAI_FUNCTION_EXPORT__?: { impl?: (init: { apiKey: string }) => unknown } }).__OPENAI_FUNCTION_EXPORT__ =
+        { impl: OpenAIImpl };
+      jest.doMock("openai", () => require("./__fixtures__/openai-function.cjs"), {
+        virtual: true,
+      });
+
+      const { generateMeta } = await import("../generateMeta");
+      const meta = await generateMeta(product);
+
+      expect(meta).toEqual({
+        title: product.title,
+        description: "AI description",
+        alt: product.title,
+        image: `/og/${product.id}.png`,
+      });
+
+      expect(OpenAIImpl).toHaveBeenCalledTimes(1);
+      expect(responsesCreate).toHaveBeenCalledTimes(1);
+      expect(imagesGenerate).toHaveBeenCalledTimes(1);
+
+      const file = path.join(process.cwd(), "public", "og", `${product.id}.png`);
+      expect(mkdirMock).toHaveBeenCalledWith(path.dirname(file), { recursive: true });
+      expect(writeMock).toHaveBeenCalledWith(file, Buffer.from(""));
+    });
+  });
+});
+

--- a/packages/lib/src/__tests__/generateMeta.resolve.test.ts
+++ b/packages/lib/src/__tests__/generateMeta.resolve.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@jest/globals";
+import type { GeneratedMeta } from "../generateMeta";
+import { resolveOpenAIConstructor } from "../generateMeta";
+
+describe("resolveOpenAIConstructor", () => {
+  it("prefers default export functions", () => {
+    const fn = function defaultExport() {
+      return {} as GeneratedMeta;
+    };
+    const result = resolveOpenAIConstructor({ default: fn });
+    expect(result).toBe(fn);
+  });
+
+  it("supports named OpenAI exports", () => {
+    const fn = function namedExport() {
+      return {} as GeneratedMeta;
+    };
+    const result = resolveOpenAIConstructor({ OpenAI: fn });
+    expect(result).toBe(fn);
+  });
+
+  it("handles nested default functions", () => {
+    const fn = function nestedExport() {
+      return {} as GeneratedMeta;
+    };
+    const result = resolveOpenAIConstructor({ default: { default: fn } });
+    expect(result).toBe(fn);
+  });
+
+  it("returns function modules directly", () => {
+    const ctor = resolveOpenAIConstructor(function OpenAI() {
+      return {} as GeneratedMeta;
+    });
+    expect(typeof ctor).toBe("function");
+  });
+
+  it("returns undefined when no constructor is present", () => {
+    expect(resolveOpenAIConstructor({})).toBeUndefined();
+  });
+});
+

--- a/packages/lib/src/__tests__/index.exports.test.ts
+++ b/packages/lib/src/__tests__/index.exports.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+describe("package root exports", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("re-exports helpers from their source modules", async () => {
+    const validateModule = await import("../validateShopName");
+    const checkModule = await import("../checkShopExists.server");
+    const generateModule = await import("../generateMeta");
+
+    const zodExports = {
+      applyFriendlyZodMessages: jest.fn(),
+      friendlyErrorMap: jest.fn(),
+    };
+
+    jest.doMock(
+      "@acme/zod-utils/zodErrorMap",
+      () => zodExports,
+      { virtual: true },
+    );
+
+    const pkg = await import("../index");
+
+    expect(pkg.validateShopName).toBe(validateModule.validateShopName);
+    expect(pkg.SHOP_NAME_RE).toBe(validateModule.SHOP_NAME_RE);
+    expect(pkg.checkShopExists).toBe(checkModule.checkShopExists);
+    expect(pkg.applyFriendlyZodMessages).toBe(zodExports.applyFriendlyZodMessages);
+    expect(pkg.friendlyErrorMap).toBe(zodExports.friendlyErrorMap);
+    expect(pkg.generateMeta).toBe(generateModule.generateMeta);
+  });
+
+  it("re-exports initZod helpers", async () => {
+    const initZodMock = jest.fn();
+    const zodExports = {
+      applyFriendlyZodMessages: jest.fn(),
+      friendlyErrorMap: jest.fn(),
+    };
+
+    jest.doMock(
+      "@acme/zod-utils/initZod",
+      () => ({ initZod: initZodMock }),
+      { virtual: true },
+    );
+
+    jest.doMock(
+      "@acme/zod-utils/zodErrorMap",
+      () => zodExports,
+      { virtual: true },
+    );
+
+    const mod = await import("../initZod");
+
+    expect(mod.initZod).toBe(initZodMock);
+    expect(mod.applyFriendlyZodMessages).toBe(zodExports.applyFriendlyZodMessages);
+    expect(mod.friendlyErrorMap).toBe(zodExports.friendlyErrorMap);
+  });
+});
+

--- a/packages/lib/src/__tests__/seoAudit.resolve.test.ts
+++ b/packages/lib/src/__tests__/seoAudit.resolve.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "@jest/globals";
+import { resolveChromeLaunch, resolveDesktopConfig, resolveLighthouse } from "../seoAudit";
+
+describe("seoAudit resolution helpers", () => {
+  it("resolves lighthouse functions from default export", () => {
+    const fn = () => undefined as never;
+    expect(resolveLighthouse({ default: fn })).toBe(fn);
+  });
+
+  it("resolves lighthouse functions from nested defaults", () => {
+    const fn = () => undefined as never;
+    expect(resolveLighthouse({ default: { default: fn } })).toBe(fn);
+  });
+
+  it("resolves lighthouse when module itself is a function", () => {
+    const fn = function lighthouse() {
+      return undefined as never;
+    };
+    expect(resolveLighthouse(fn)).toBe(fn);
+  });
+
+  it("returns undefined when lighthouse constructor missing", () => {
+    expect(resolveLighthouse({})).toBeUndefined();
+  });
+
+  it("resolves chrome launch from multiple shapes", () => {
+    const direct = () => undefined as never;
+    const fromDefault = () => undefined as never;
+    const fromNested = () => undefined as never;
+    expect(resolveChromeLaunch({ launch: direct })).toBe(direct);
+    expect(resolveChromeLaunch({ default: { launch: fromDefault } })).toBe(fromDefault);
+    expect(resolveChromeLaunch({ default: { default: { launch: fromNested } } })).toBe(fromNested);
+    expect(resolveChromeLaunch({})).toBeUndefined();
+  });
+
+  it("prefers desktop config defaults", () => {
+    const mod = { default: { extends: "lighthouse:default" } };
+    expect(resolveDesktopConfig(mod)).toBe(mod.default);
+    const fallback = { alt: true };
+    expect(resolveDesktopConfig(fallback)).toBe(fallback);
+  });
+});
+

--- a/packages/lib/src/__tests__/seoAudit.test.ts
+++ b/packages/lib/src/__tests__/seoAudit.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, afterEach, jest } from "@jest/globals";
+
+describe("runSeoAudit", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("throws when chrome launch function is unavailable", async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock("lighthouse", () => jest.fn(), { virtual: true });
+      jest.doMock("chrome-launcher", () => ({}), { virtual: true });
+      jest.doMock(
+        "lighthouse/core/config/desktop-config.js",
+        () => ({ default: {} }),
+        { virtual: true },
+      );
+
+      const { runSeoAudit } = await import("../seoAudit");
+      await expect(runSeoAudit("https://example.com")).rejects.toThrow(
+        "chrome-launcher launch function not available",
+      );
+    });
+  });
+
+  it("throws when lighthouse export is not a function", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const chrome = { port: 9222, kill: jest.fn().mockResolvedValue(undefined) };
+      jest.doMock(
+        "chrome-launcher",
+        () => ({ launch: jest.fn().mockResolvedValue(chrome) }),
+        { virtual: true },
+      );
+      jest.doMock("lighthouse", () => ({ default: {} }), { virtual: true });
+      jest.doMock(
+        "lighthouse/core/config/desktop-config.js",
+        () => ({ default: {} }),
+        { virtual: true },
+      );
+
+      const { runSeoAudit } = await import("../seoAudit");
+      await expect(runSeoAudit("https://example.com")).rejects.toThrow("lighthouse is not a function");
+    });
+  });
+
+  it("throws when desktop config cannot be resolved", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const chrome = { port: 9222, kill: jest.fn().mockResolvedValue(undefined) };
+      jest.doMock(
+        "chrome-launcher",
+        () => ({ launch: jest.fn().mockResolvedValue(chrome) }),
+        { virtual: true },
+      );
+      const lighthouseFn = jest.fn();
+      jest.doMock("lighthouse", () => lighthouseFn, { virtual: true });
+      jest.doMock(
+        "lighthouse/core/config/desktop-config.js",
+        () => {
+          throw new Error("missing");
+        },
+        { virtual: true },
+      );
+
+      const { runSeoAudit } = await import("../seoAudit");
+      await expect(runSeoAudit("https://example.com")).rejects.toThrow(
+        "lighthouse desktop config not available",
+      );
+    });
+  });
+
+  it("throws when Lighthouse returns no result", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const chrome = { port: 9333, kill: jest.fn().mockResolvedValue(undefined) };
+      const launch = jest.fn().mockResolvedValue(chrome);
+      const lighthouseFn = jest.fn().mockResolvedValue(undefined);
+
+      jest.doMock("lighthouse", () => lighthouseFn, { virtual: true });
+      jest.doMock("chrome-launcher", () => ({ launch }), { virtual: true });
+      jest.doMock(
+        "lighthouse/core/config/desktop-config.js",
+        () => ({ default: {} }),
+        { virtual: true },
+      );
+
+      const { runSeoAudit } = await import("../seoAudit");
+      await expect(runSeoAudit("https://example.net")).rejects.toThrow(
+        "Lighthouse did not return a result",
+      );
+      expect(chrome.kill).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("returns audit results with recommendations", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const chrome = { port: 9222, kill: jest.fn().mockResolvedValue(undefined) };
+      const launch = jest.fn().mockResolvedValue(chrome);
+      const lighthouseFn = jest.fn().mockResolvedValue({
+        lhr: {
+          categories: { seo: { score: 0.91 } },
+          audits: {
+            pass: { score: 1, scoreDisplayMode: "binary", title: "pass" },
+            fail: { score: 0, scoreDisplayMode: "binary", title: "Improve alt text" },
+            na: { score: 0, scoreDisplayMode: "notApplicable", title: "N/A" },
+          },
+        },
+      });
+
+      jest.doMock("lighthouse", () => lighthouseFn, { virtual: true });
+      jest.doMock("chrome-launcher", () => ({ launch }), { virtual: true });
+      jest.doMock(
+        "lighthouse/core/config/desktop-config.js",
+        () => ({ default: { extends: "lighthouse:default" } }),
+        { virtual: true },
+      );
+
+      const { runSeoAudit } = await import("../seoAudit");
+      const result = await runSeoAudit("https://example.com");
+
+      expect(result).toEqual({ score: 91, recommendations: ["Improve alt text"] });
+      expect(launch).toHaveBeenCalledWith({ chromeFlags: ["--headless"] });
+      expect(chrome.kill).toHaveBeenCalledTimes(1);
+      expect(lighthouseFn).toHaveBeenCalledTimes(1);
+      const [urlArg, optsArg, configArg] = (lighthouseFn as jest.Mock).mock.calls[0];
+      expect(urlArg).toBe("https://example.com");
+      expect(optsArg).toMatchObject({ onlyCategories: ["seo"], port: chrome.port });
+      if (configArg && typeof configArg === "object") {
+        const normalized = (configArg as { default?: unknown }).default ?? configArg;
+        expect(normalized).toMatchObject({ extends: "lighthouse:default" });
+      } else {
+        throw new Error("Expected desktop config object");
+      }
+    });
+  });
+
+  it("supports direct function exports and plain config modules", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const chrome = { port: 9223, kill: jest.fn().mockResolvedValue(undefined) };
+      const launch = jest.fn().mockResolvedValue(chrome);
+      const lighthouseFn = jest.fn().mockResolvedValue({
+        lhr: {
+          categories: { seo: { score: 0.5 } },
+          audits: {
+            fail: { score: 0, scoreDisplayMode: "binary", title: "Fix meta" },
+          },
+        },
+      });
+
+      const actualTslib = jest.requireActual("tslib");
+      jest.doMock(
+        "tslib",
+        () => ({
+          ...actualTslib,
+          __importStar: (mod: unknown) => mod,
+        }),
+        { virtual: true },
+      );
+      jest.doMock("lighthouse", () => lighthouseFn, { virtual: true });
+      jest.doMock("chrome-launcher", () => ({ launch }), { virtual: true });
+      jest.doMock(
+        "lighthouse/core/config/desktop-config.js",
+        () => ({ extends: "direct" }),
+        { virtual: true },
+      );
+
+      const { runSeoAudit } = await import("../seoAudit");
+      const result = await runSeoAudit("https://example.org");
+
+      expect(result).toEqual({ score: 50, recommendations: ["Fix meta"] });
+      expect(lighthouseFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("defaults the SEO score to zero when the category is missing", async () => {
+    await jest.isolateModulesAsync(async () => {
+      const chrome = { port: 9224, kill: jest.fn().mockResolvedValue(undefined) };
+      const launch = jest.fn().mockResolvedValue(chrome);
+      const lighthouseFn = jest.fn().mockResolvedValue({
+        lhr: {
+          categories: {},
+          audits: {
+            missing: { score: 0, scoreDisplayMode: "binary", title: "Add descriptions" },
+          },
+        },
+      });
+
+      jest.doMock("lighthouse", () => lighthouseFn, { virtual: true });
+      jest.doMock("chrome-launcher", () => ({ launch }), { virtual: true });
+      jest.doMock(
+        "lighthouse/core/config/desktop-config.js",
+        () => ({ default: {} }),
+        { virtual: true },
+      );
+
+      const { runSeoAudit } = await import("../seoAudit");
+      const result = await runSeoAudit("https://example.dev");
+
+      expect(result).toEqual({ score: 0, recommendations: ["Add descriptions"] });
+      expect(lighthouseFn).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+

--- a/packages/lib/src/tryon/__tests__/circuitBreaker.test.ts
+++ b/packages/lib/src/tryon/__tests__/circuitBreaker.test.ts
@@ -1,0 +1,71 @@
+jest.mock(
+  "@acme/i18n/en.json",
+  () => ({
+    __esModule: true,
+    default: {
+      "tryon.circuitBreaker.timeout": "Timeout.",
+      "tryon.circuitBreaker.open": "Circuit open.",
+      "tryon.circuitBreaker.halfOpen": "Circuit half-open.",
+    },
+  }),
+  { virtual: true },
+);
+
+import { describe, expect, it, afterEach, jest } from "@jest/globals";
+import { createBreaker } from "../providers/circuitBreaker";
+
+describe("createBreaker", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("rejects slow operations with a timeout", async () => {
+    jest.useFakeTimers();
+    const breaker = createBreaker({ timeoutMs: 10, failureThreshold: 2, coolOffMs: 100 });
+
+    const pending = breaker.exec("task", () => new Promise(() => {}));
+
+    jest.advanceTimersByTime(10);
+
+    await expect(pending).rejects.toThrow("Timeout.");
+  });
+
+  it("transitions between closed, open and half-open states", async () => {
+    const breaker = createBreaker({ timeoutMs: 0, failureThreshold: 2, coolOffMs: 100 });
+
+    let now = 0;
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    const fail = jest.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(breaker.exec("svc", fail)).rejects.toThrow("boom");
+
+    now = 10;
+    await expect(breaker.exec("svc", fail)).rejects.toThrow("boom");
+
+    now = 50;
+    await expect(breaker.exec("svc", async () => "ignored")).rejects.toThrow("Circuit open.");
+
+    now = 200;
+    let release!: (value: string) => void;
+    const first = breaker.exec(
+      "svc",
+      () =>
+        new Promise<string>((resolve) => {
+          release = resolve;
+        }),
+    );
+
+    await expect(breaker.exec("svc", async () => "second"))
+      .rejects.toThrow("Circuit half-open.");
+
+    release("ok");
+
+    await expect(first).resolves.toBe("ok");
+
+    now = 400;
+    await expect(breaker.exec("svc", async () => "success")).resolves.toBe("success");
+  });
+});
+

--- a/packages/lib/src/tryon/__tests__/cloudflare.test.ts
+++ b/packages/lib/src/tryon/__tests__/cloudflare.test.ts
@@ -20,7 +20,8 @@ jest.mock(
   { virtual: true }
 );
 
-import { createCloudflareProvider } from "../providers/cloudflare";
+import * as cloudflare from "../providers/cloudflare";
+import { BUDGET } from "../index";
 
 class MockFormData {
   private entries: Array<[string, unknown, string | undefined]> = [];
@@ -50,7 +51,7 @@ describe("createCloudflareProvider", () => {
 
   it("returns an empty result when the account id is missing", async () => {
     delete process.env.CLOUDFLARE_ACCOUNT_ID;
-    const provider = createCloudflareProvider();
+    const provider = cloudflare.createCloudflareProvider();
     await expect(provider.segmenter!.run("https://example.com/image.png")).resolves.toEqual({});
   });
 
@@ -74,7 +75,7 @@ describe("createCloudflareProvider", () => {
 
     global.fetch = jest.fn(() => Promise.resolve(responses.shift()!)) as unknown as typeof fetch;
 
-    const provider = createCloudflareProvider();
+    const provider = cloudflare.createCloudflareProvider();
     const result = await provider.segmenter!.run("https://acct.r2.cloudflarestorage.com/photo.png");
 
     expect(global.fetch).toHaveBeenCalledTimes(2);
@@ -85,7 +86,7 @@ describe("createCloudflareProvider", () => {
   it("rejects when the image origin is not allowed", async () => {
     process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
     process.env.CLOUDFLARE_AI_GATEWAY_ID = "gateway";
-    const provider = createCloudflareProvider();
+    const provider = cloudflare.createCloudflareProvider();
 
     await expect(provider.segmenter!.run("https://malicious.example.com/photo.png")).rejects.toThrow(
       "Origin not allowed."
@@ -111,9 +112,375 @@ describe("createCloudflareProvider", () => {
 
     global.fetch = jest.fn(() => Promise.resolve(responses.shift()!)) as unknown as typeof fetch;
 
-    const provider = createCloudflareProvider();
+    const provider = cloudflare.createCloudflareProvider();
     const result = await provider.segmenter!.run("https://acct.r2.cloudflarestorage.com/photo.png");
 
     expect(result.error).toEqual({ code: "PROVIDER_UNAVAILABLE", details: "No image in JSON." });
+  });
+
+  it("propagates fetch failures when downloading images", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.R2_PUBLIC_BASE_URL = "https://r2.example.com/assets";
+
+    const responses: Response[] = [
+      new Response(null, { status: 403 }),
+    ];
+
+    global.fetch = jest.fn(() => Promise.resolve(responses.shift()!)) as unknown as typeof fetch;
+
+    const provider = cloudflare.createCloudflareProvider();
+
+    await expect(provider.segmenter!.run("https://r2.example.com/assets/photo.png")).rejects.toThrow(
+      "Failed to fetch image (403).",
+    );
+  });
+
+  it("requires an API token when Workers AI gateway is not configured", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+    delete process.env.CLOUDFLARE_API_TOKEN;
+
+    const responses: Response[] = [
+      { ok: true, blob: async () => new Blob(["image"], { type: "image/png" }) } as Response,
+    ];
+
+    global.fetch = jest.fn(() => Promise.resolve(responses.shift()!)) as unknown as typeof fetch;
+
+    const provider = cloudflare.createCloudflareProvider();
+    const result = await provider.segmenter!.run("https://acct.r2.cloudflarestorage.com/photo.png");
+
+    expect(result).toEqual({
+      error: { code: "PROVIDER_UNAVAILABLE", details: "CLOUDFLARE_API_TOKEN missing." },
+    });
+  });
+
+  it("returns binary image payloads from Workers AI", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.CLOUDFLARE_API_TOKEN = "token";
+    delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+
+    const pngBytes = new Uint8Array([0, 1, 2, 3]);
+
+    const responses: Response[] = [
+      { ok: true, blob: async () => new Blob(["image"], { type: "image/png" }) } as Response,
+      {
+        ok: true,
+        headers: { get: (name: string) => (name === "content-type" ? "image/png" : null) } as unknown as Headers,
+        arrayBuffer: async () => pngBytes.buffer,
+      } as unknown as Response,
+    ];
+
+    global.fetch = jest.fn(() => Promise.resolve(responses.shift()!)) as unknown as typeof fetch;
+
+    const provider = cloudflare.createCloudflareProvider();
+    const result = await provider.depth!.run("https://acct.r2.cloudflarestorage.com/photo.png");
+
+    expect(result.result?.url).toBe(`data:image/png;base64,${Buffer.from(pngBytes).toString("base64")}`);
+    expect(result.metrics?.preprocessMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports missing account ids discovered during processing", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.CLOUDFLARE_AI_GATEWAY_ID = "gateway";
+    process.env.R2_PUBLIC_BASE_URL = "https://acct.r2.cloudflarestorage.com/assets";
+
+    const firstResponse = new Response(null, { status: 200 });
+    Object.defineProperty(firstResponse, "ok", { value: true });
+    jest.spyOn(firstResponse, "blob").mockImplementation(async () => {
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+      return new Blob(["image"], { type: "image/png" });
+    });
+
+    const responses: Response[] = [
+      firstResponse,
+    ];
+
+    global.fetch = jest.fn(() => Promise.resolve(responses.shift()!)) as unknown as typeof fetch;
+
+    const provider = cloudflare.createCloudflareProvider();
+    const result = await provider.segmenter!.run("https://acct.r2.cloudflarestorage.com/photo.png");
+
+    expect(result).toEqual({
+      error: { code: "PROVIDER_UNAVAILABLE", details: "CLOUDFLARE_ACCOUNT_ID missing." },
+    });
+  });
+
+  it("returns upstream errors from Workers AI", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.CLOUDFLARE_API_TOKEN = "token";
+    delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+
+    const responses: Response[] = [
+      { ok: true, blob: async () => new Blob(["image"], { type: "image/png" }) } as Response,
+      {
+        ok: false,
+        status: 502,
+        headers: { get: () => null } as unknown as Headers,
+      } as unknown as Response,
+    ];
+
+    global.fetch = jest.fn(() => Promise.resolve(responses.shift()!)) as unknown as typeof fetch;
+
+    const provider = cloudflare.createCloudflareProvider();
+    const result = await provider.depth!.run("https://acct.r2.cloudflarestorage.com/photo.png");
+
+    expect(result).toEqual({
+      error: { code: "PROVIDER_UNAVAILABLE", details: "Upstream 502." },
+    });
+  });
+
+  it("propagates depth provider errors returned from Workers AI", async () => {
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    process.env.CLOUDFLARE_API_TOKEN = "token";
+    delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+
+    const responses: Response[] = [
+      { ok: true, blob: async () => new Blob(["image"], { type: "image/png" }) } as Response,
+      {
+        ok: true,
+        headers: { get: () => "application/json" } as unknown as Headers,
+        json: async () => ({}),
+        arrayBuffer: async () => new ArrayBuffer(0),
+      } as unknown as Response,
+    ];
+
+    global.fetch = jest.fn(() => Promise.resolve(responses.shift()!)) as unknown as typeof fetch;
+
+    const provider = cloudflare.createCloudflareProvider();
+    const result = await provider.depth!.run("https://acct.r2.cloudflarestorage.com/photo.png");
+
+    expect(result).toEqual({
+      error: { code: "PROVIDER_UNAVAILABLE", details: "No image in JSON." },
+    });
+  });
+
+  it("returns an empty depth result when the account id is missing", async () => {
+    delete process.env.CLOUDFLARE_ACCOUNT_ID;
+
+    const provider = cloudflare.createCloudflareProvider();
+    const result = await provider.depth!.run("https://example.com/photo.png");
+
+    expect(result).toEqual({});
+  });
+
+  describe("runWorkersAi", () => {
+    it("defaults the content type when the response header is missing", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_API_TOKEN = "token";
+      delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+
+      const bytes = new Uint8Array([7, 8, 9]);
+      global.fetch = jest.fn(async () => new Response(bytes, { status: 200 })) as unknown as typeof fetch;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(result.contentType).toBe("application/octet-stream");
+      expect(Buffer.from(new Uint8Array(result.body))).toEqual(Buffer.from(bytes));
+    });
+
+    it("returns an error when the account id is missing", async () => {
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+      const blob = new Blob(["image"], { type: "image/png" });
+
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(result).toEqual({ error: "CLOUDFLARE_ACCOUNT_ID missing." });
+    });
+
+    it("requires an API token when the gateway is not configured", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      delete process.env.CLOUDFLARE_API_TOKEN;
+      delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(result).toEqual({ error: "CLOUDFLARE_API_TOKEN missing." });
+    });
+
+    it("returns upstream errors when Workers AI fails", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_API_TOKEN = "token";
+      delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+
+      global.fetch = jest.fn(async () =>
+        new Response(null, { status: 503, headers: { "content-type": "application/json" } })
+      ) as unknown as typeof fetch;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(result).toEqual({ error: "Upstream 503." });
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.cloudflare.com/client/v4/accounts/acct/ai/run/model",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    it("returns binary payloads when the response is not JSON", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_API_TOKEN = "token";
+      delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+
+      const buffer = new Uint8Array([0, 1, 2]).buffer;
+      global.fetch = jest.fn(async () =>
+        new Response(buffer, { status: 200, headers: { "content-type": "image/png" } })
+      ) as unknown as typeof fetch;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(Buffer.from(new Uint8Array(result.body))).toEqual(Buffer.from([0, 1, 2]));
+      expect(result.contentType).toBe("image/png");
+    });
+
+    it("uses the Workers AI gateway when configured", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_AI_GATEWAY_ID = "gateway";
+      delete process.env.CLOUDFLARE_API_TOKEN;
+
+      const base64 = Buffer.from("gateway").toString("base64");
+      global.fetch = jest.fn(async () =>
+        new Response(JSON.stringify({ result: { image: base64 } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      ) as unknown as typeof fetch;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(Buffer.from(new Uint8Array(result.body)).toString()).toBe("gateway");
+      expect(result.contentType).toBe("image/png");
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://gateway.ai.cloudflare.com/v1/acct/gateway/workers-ai/run/model",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    it("accepts base64 payloads in top-level image fields", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_AI_GATEWAY_ID = "gateway";
+
+      const base64 = Buffer.from("top-level").toString("base64");
+      global.fetch = jest.fn(async () =>
+        new Response(JSON.stringify({ image: base64 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      ) as unknown as typeof fetch;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(Buffer.from(new Uint8Array(result.body)).toString()).toBe("top-level");
+      expect(result.contentType).toBe("image/png");
+    });
+
+    it("accepts base64 payloads from nested output arrays", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_AI_GATEWAY_ID = "gateway";
+
+      const base64 = Buffer.from("nested").toString("base64");
+      global.fetch = jest.fn(async () =>
+        new Response(JSON.stringify({ result: { output: [base64] } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      ) as unknown as typeof fetch;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(Buffer.from(new Uint8Array(result.body)).toString()).toBe("nested");
+    });
+
+    it("returns an error when JSON payloads lack an image field", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_AI_GATEWAY_ID = "gateway";
+
+      global.fetch = jest.fn(async () =>
+        new Response(JSON.stringify({ result: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      ) as unknown as typeof fetch;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(result).toEqual({ error: "No image in JSON." });
+    });
+
+    it("handles JSON parse failures by returning an error", async () => {
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_AI_GATEWAY_ID = "gateway";
+
+      global.fetch = jest.fn(async () => {
+        const response = new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+        jest.spyOn(response, "json").mockRejectedValue(new Error("boom"));
+        return response;
+      }) as unknown as typeof fetch;
+
+      const blob = new Blob(["image"], { type: "image/png" });
+      const result = await cloudflare.runWorkersAi("model", blob);
+
+      expect(result).toEqual({ error: "No image in JSON." });
+    });
+
+    it("aborts the request when the preprocess budget elapses", async () => {
+      jest.useFakeTimers();
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      process.env.CLOUDFLARE_API_TOKEN = "token";
+      delete process.env.CLOUDFLARE_AI_GATEWAY_ID;
+
+      global.fetch = jest.fn((_, init?: RequestInit) =>
+        new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        })
+      ) as unknown as typeof fetch;
+
+      try {
+        const blob = new Blob(["image"], { type: "image/png" });
+        const promise = cloudflare.runWorkersAi("model", blob);
+
+        jest.advanceTimersByTime(BUDGET.preprocessMs + 1);
+
+        await expect(promise).rejects.toThrow("aborted");
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe("formatWorkersAiOutput", () => {
+    it("uses the provided content type", () => {
+      const started = 1000;
+      const now = 1100;
+      const body = new Uint8Array([1, 2]).buffer;
+      const result = cloudflare.formatWorkersAiOutput({ contentType: "image/jpeg", body }, started, now);
+
+      expect(result).toEqual({
+        result: { url: expect.stringMatching(/^data:image\/jpeg;base64,/), width: 0, height: 0 },
+        metrics: { preprocessMs: now - started },
+      });
+    });
+
+    it("defaults to PNG when the content type is missing", () => {
+      const started = 2000;
+      const now = 2100;
+      const body = new Uint8Array([3, 4]).buffer;
+      const result = cloudflare.formatWorkersAiOutput({ body }, started, now);
+
+      expect(result).toEqual({
+        result: { url: expect.stringMatching(/^data:image\/png;base64,/), width: 0, height: 0 },
+        metrics: { preprocessMs: now - started },
+      });
+    });
   });
 });

--- a/packages/lib/src/tryon/__tests__/i18n.test.ts
+++ b/packages/lib/src/tryon/__tests__/i18n.test.ts
@@ -38,4 +38,8 @@ describe("t", () => {
   it("stringifies provided values", () => {
     expect(t("tryon.providers.cloudflare.upstreamError", { status: true })).toBe("Upstream true.");
   });
+
+  it("preserves placeholders when a variable is explicitly undefined", () => {
+    expect(t("tryon.providers.cloudflare.upstreamError", { status: undefined })).toBe("Upstream {status}.");
+  });
 });

--- a/packages/lib/src/tryon/__tests__/shadow.test.ts
+++ b/packages/lib/src/tryon/__tests__/shadow.test.ts
@@ -45,4 +45,23 @@ describe("renderShadow", () => {
     expect((ctx as any).globalCompositeOperation).toBe("multiply");
     expect((ctx as any).fillStyle).toBe(gradient);
   });
+
+  it("uses default options when none are provided", () => {
+    const gradient = { addColorStop: jest.fn() };
+    const ctx = {
+      save: jest.fn(),
+      restore: jest.fn(),
+      beginPath: jest.fn(),
+      ellipse: jest.fn(),
+      fill: jest.fn(),
+      createRadialGradient: jest.fn(() => gradient),
+      globalCompositeOperation: "source-over",
+      fillStyle: "",
+    } as unknown as CanvasRenderingContext2D;
+
+    renderShadow(ctx, { x: 0, y: 0, width: 20, height: 10 });
+
+    expect(gradient.addColorStop).toHaveBeenCalledWith(0, "rgba(0,0,0,0.35)");
+    expect(ctx.ellipse).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- expose resolver helpers in generateMeta, seoAudit, and the Cloudflare provider so branchy logic can be unit tested directly
- add exhaustive tests for SEO auditing, OpenAI metadata generation, and Workers AI interactions to reach full coverage
- verify managed try-on provider scenarios including error handling and varied payload shapes

## Testing
- pnpm --filter @acme/lib test

------
https://chatgpt.com/codex/tasks/task_e_68dcd88d5940832f920abd72fd715505